### PR TITLE
basic-launchbar-config: personalized launchbar. 

### DIFF
--- a/virtual-desktop/pluginDefinition.json
+++ b/virtual-desktop/pluginDefinition.json
@@ -15,6 +15,19 @@
       "actions": {
         "locationType": "relative",
         "aggregationPolicy": "none"
+      },
+      "ui": {
+        "subResources":{
+          "launchbar": {
+            "subResources": {
+              "plugins": {
+                "aggregationPolicy": "override",
+                "variable": false,
+                "locationType": "relative"
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/context-menu/context-menu.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/context-menu/context-menu.component.css
@@ -12,7 +12,7 @@
 
 .context-menu {
   position: absolute;
-  z-index: 999;
+  z-index: 20000;
   min-width: 180px;
   width: auto;
 }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/desktop/desktop.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/desktop/desktop.component.html
@@ -10,6 +10,10 @@
   Copyright Contributors to the Zowe Project.
 -->
 
+<ng-container *ngIf="contextMenuDef != null">
+  <com-rs-mvd-context-menu [xPos]="contextMenuDef.xPos" [yPos]="contextMenuDef.yPos" [menuItems]="contextMenuDef.items" (complete)="closeContextMenu()"></com-rs-mvd-context-menu>
+</ng-container>
+
 <rs-com-window-pane></rs-com-window-pane>
 <rs-com-launchbar></rs-com-launchbar>
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/desktop/desktop.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/desktop/desktop.component.ts
@@ -12,18 +12,32 @@
 
 import { Component, Inject } from '@angular/core';
 import { Http, Response } from '@angular/http';
+import { ContextMenuItem } from 'pluginlib/inject-resources';
+import { WindowManagerService } from '../shared/window-manager.service';
 
 @Component({
   selector: 'rs-com-mvd-desktop',
   templateUrl: 'desktop.component.html'
 })
 export class DesktopComponent {
-  constructor(
+contextMenuDef: {xPos: number, yPos: number, items: ContextMenuItem[]} | null;
+
+constructor(
+    public windowManager: WindowManagerService,
     private http: Http,
     @Inject(MVDHosting.Tokens.AuthenticationManagerToken) private authenticationManager: MVDHosting.AuthenticationManagerInterface
   ) {
-    
+    this.contextMenuDef = null;
     this.authenticationManager.registerPostLoginAction(new AppDispatcherLoader(this.http));
+  }
+  ngOnInit(): void {
+    this.windowManager.contextMenuRequested.subscribe(menuDef => {
+      this.contextMenuDef = menuDef;
+    });
+  }
+
+  closeContextMenu(): void {
+    this.contextMenuDef = null;
   }
 }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
@@ -17,7 +17,7 @@
 
 <ng-template [ngIf]="isActive">
   <div class="launch-widget-popup">
-    <div class="launch-widget-row" *ngFor="let item of menuItems" (click)="clicked(item)">
+    <div class="launch-widget-row" *ngFor="let item of menuItems" (click)="clicked(item)" (contextmenu)="onRightClick($event, item)">
       <img class="icon" [src]="item.image">
       <p>{{item.label}}</p>
     </div>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.css
@@ -21,6 +21,9 @@
   margin: 0;
   padding: 0;
   z-index: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
 }
 
 .launchbar-container.active {
@@ -41,15 +44,20 @@
 .launchbar {
   height: 110px;
   box-sizing: border-box;
-  display: inline-block;
+  display: flex;
   background: transparent;
-  text-align: center;
+  text-align: left;
   z-index: 6;
   margin: 0;
   margin-left: 130px; /* Prevent overlap with launch widget on the left */
   margin-right: 150px; /* Prevent overlap with lauchbar clock and searcb bar on the right */
   padding: 0;
   padding-left: 25px;
+  padding-top: 0;
+}
+
+rs-com-launchbar-icon {
+  text-align: center;
 }
 
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
@@ -10,10 +10,14 @@
   Copyright Contributors to the Zowe Project.
 -->
 
-<div class="launchbar-container" [class.active]="isActive">
+<div class="launchbar-container" id="container" [class.active]="isActive" (mousedown)="onMouseDownContainer($event)" (mousemove)="onMouseMoveContainer($event)" (mouseup)="onMouseUpContainer($event)">
   <rs-com-launchbar-menu [menuItems]="allItems" (itemClicked)="menuItemClicked($event)"  (menuStateChanged)="onStateChanged($event)"></rs-com-launchbar-menu>
   <div class="launchbar">
-    <rs-com-launchbar-icon *ngFor="let item of pinnedItems" [launchbarItem]="item" (iconClicked)="pinnedItemClicked(item)">
+    <rs-com-launchbar-icon *ngFor="let item of pinnedItems" [launchbarItem]="item" (contextmenu)="onRightClick($event, item)"
+    (mousedown)="onMouseDown($event, item)" (mousemove)="onMouseMove($event, item)">
+    </rs-com-launchbar-icon>
+    <rs-com-launchbar-icon *ngFor="let item of runningItems" [launchbarItem]="item" (contextmenu)="onRightClick($event, item)"
+    (mousedown)="onMouseDown($event, item)">
     </rs-com-launchbar-icon>
   </div>
   <rs-com-launchbar-widget (popupStateChanged)="onStateChanged($event)"></rs-com-launchbar-widget>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -11,38 +11,74 @@
 */
 
 import { Component, Inject } from '@angular/core';
-
+import { Subject } from 'rxjs/Subject';
 import { LaunchbarItem } from '../shared/launchbar-item';
 import { PluginLaunchbarItem } from '../shared/launchbar-items/plugin-launchbar-item';
 import { DesktopPluginDefinitionImpl } from "app/plugin-manager/shared/desktop-plugin-definition";
+import { ContextMenuItem } from 'pluginlib/inject-resources';
+import { WindowManagerService } from '../../shared/window-manager.service';
+import { PluginsDataService } from '../../services/plugins-data.service';
+
 
 @Component({
   selector: 'rs-com-launchbar',
   templateUrl: './launchbar.component.html',
-  styleUrls: ['./launchbar.component.css']
+  styleUrls: ['./launchbar.component.css'],
+  providers: [PluginsDataService]
 })
 export class LaunchbarComponent {
   allItems: LaunchbarItem[];
+  runItems: LaunchbarItem[];
   private isActive: boolean;
+  contextMenuRequested: Subject<{xPos: number, yPos: number, items: ContextMenuItem[]}>;
+  originalX: number;
+  mouseOriginalX: number;
+  currentEvent: EventTarget | null; 
+  currentItem: LaunchbarItem | null;
+  moving: boolean;
+  newPosition: number;
+  loggedIn: boolean;
+  helperLoggedIn: boolean;
 
   constructor(
+    private pluginsDataService: PluginsDataService,
     @Inject(MVDHosting.Tokens.PluginManagerToken) public pluginManager: MVDHosting.PluginManagerInterface,
-    @Inject(MVDHosting.Tokens.ApplicationManagerToken) public applicationManager: MVDHosting.ApplicationManagerInterface
+    @Inject(MVDHosting.Tokens.ApplicationManagerToken) public applicationManager: MVDHosting.ApplicationManagerInterface,
+    @Inject(MVDHosting.Tokens.AuthenticationManagerToken) public authenticationManager: MVDHosting.AuthenticationManagerInterface,
+    public windowManager: WindowManagerService,
   ) {
     this.allItems = [];
+    this.runItems = [];
     this.isActive = false;
+    this.contextMenuRequested = new Subject();
+    this.loggedIn = false;
+    this.helperLoggedIn = false; //helperLoggedIn is to indicate when the initial login happens
   }
 
   ngOnInit(): void {
     this.allItems = [];
-
     this.pluginManager.loadApplicationPluginDefinitions().then(pluginDefinitions => {
       pluginDefinitions.forEach((p)=> {
         if (p.getBasePlugin().getWebContent() != null) {
           this.allItems.push(new PluginLaunchbarItem(p as DesktopPluginDefinitionImpl));
         }
-      });
+      })
     });
+  }
+
+  ngDoCheck(): void {
+    if (this.authenticationManager.getUsername() != null) {
+      this.loggedIn = true;
+    } else {
+      this.loggedIn = false;
+      this.helperLoggedIn = false;
+    }
+    if (this.loggedIn) {
+      if(this.helperLoggedIn != true){
+        this.pluginsDataService.refreshPinnedPlugins();
+        this.helperLoggedIn = true; 
+      }
+    }
   }
 
   activeToggle(): void {
@@ -50,19 +86,169 @@ export class LaunchbarComponent {
   }
 
   get pinnedItems(): LaunchbarItem[] {
-    return this.allItems.filter(item => item.pinned);
+    return this.pluginsDataService.pinnedPlugins;
   }
 
-  pinnedItemClicked(item: LaunchbarItem): void {
-    this.applicationManager.showApplicationWindow(item.plugin);
+  get runningItems(): LaunchbarItem[] {
+    let openPlugins = this.allItems.filter(item => 
+                                this.applicationManager.isApplicationRunning(item.plugin));
+    let openItems: LaunchbarItem[];
+    openItems = [];
+    openPlugins.forEach(p => {
+      if (!this.pluginsDataService.isPinnedPlugin(p)){
+        openItems.push(p);
+      }
+    })
+    return openItems;
   }
-
   menuItemClicked(item: LaunchbarItem): void {
     this.applicationManager.showApplicationWindow(item.plugin);
   }
 
+  launchbarItemClicked(item: LaunchbarItem): void {
+    if (this.applicationManager.isApplicationRunning(item.plugin)) {
+      let windowId = this.windowManager.getWindow(item.plugin);
+      if (windowId != null) {
+        this.windowManager.minimizeToggle(windowId);
+      }
+    } else {
+      this.applicationManager.showApplicationWindow(item.plugin);
+    }
+  }
+
   onStateChanged(isActive: boolean): void {
     this.isActive = isActive;
+    }
+
+  closeApplication(item: LaunchbarItem): void {
+    let windowId = this.windowManager.getWindow(item.plugin);
+    if (windowId != null) {
+      this.windowManager.closeWindow(windowId);
+    }
+  }
+
+  onRightClick(event: MouseEvent, item: LaunchbarItem): boolean {
+    if (this.applicationManager.isApplicationRunning(item.plugin)) {
+      var menuItems: ContextMenuItem[] =
+        [
+          this.pluginsDataService.pinContext(item),
+          { "text": "Bring to Front", "action": () => this.bringItemFront(item) },
+          { "text": "Close", "action": () => this.closeApplication(item) },
+        ];
+    } else {
+      var menuItems: ContextMenuItem[] =
+        [
+          { "text": "Open", "action": () => this.launchbarItemClicked(item) },
+          this.pluginsDataService.pinContext(item)
+        ]
+    }
+    this.windowManager.contextMenuRequested.next({xPos: event.clientX, yPos: event.clientY - 60, items: menuItems});
+    return false;
+  }
+
+  bringItemFront(item: LaunchbarItem): void {
+    let windowId = this.windowManager.getWindow(item.plugin);
+    if (windowId != null) {
+      this.windowManager.requestWindowFocus(windowId);
+    }
+  }
+
+  onMouseDown(event: MouseEvent, item: LaunchbarItem): void {
+    (<HTMLImageElement>event.target).style.zIndex = '999';
+      this.originalX = (<HTMLImageElement>event.target).getBoundingClientRect().left
+      this.mouseOriginalX = event.clientX;
+      if (event.target != null){
+        this.currentItem = item;
+        this.currentEvent = event.target;
+      }
+    if(event.button == 3){
+      this.onRightClick(event, item);
+    }
+  }
+
+  onMouseMove(event: MouseEvent, item: LaunchbarItem): void{
+    let widget = document.getElementsByClassName("launch-widget");
+    let clockStart = window.innerWidth - document.getElementsByClassName("launchbar-clock")[0].clientWidth;
+    if(event.which == 1){
+      let mouseDifference = event.clientX - this.mouseOriginalX;
+      if (Math.abs(mouseDifference) > 5 && event.target == this.currentEvent &&
+          event.clientX > widget[0].clientWidth + 30 && event.clientX < clockStart - 65) {
+        this.moving = true;
+        (<HTMLImageElement>event.target).style.position = 'absolute';
+        (<HTMLImageElement>event.target).style.left = (event.clientX - 30) + 'px';
+      } else if (event.clientX < widget[0].clientWidth) {
+        (<HTMLImageElement>event.target).style.left = widget[0].clientWidth +'px';
+      } else if (event.clientX > clockStart - 35) {
+        (<HTMLImageElement>event.target).style.left = (clockStart - 65) + 'px';
+      }
+    }
+  }
+
+  onMouseUpContainer(event: MouseEvent): void {
+    let container = document.getElementById("container");
+    if (container != null) {
+      container.style.height = 110 + 'px';
+    }
+    if (this.currentItem != null) {
+      this.onMouseUp(event, this.currentItem);
+    }
+  }
+
+  onMouseDownContainer(event: MouseEvent): void {
+    let container = document.getElementById("container");
+    if (container != null) {
+      container.style.height = 100 + "%";
+    }
+  }
+
+  onMouseUp(event: MouseEvent, item: LaunchbarItem): void {
+      let mouseDifference = event.clientX - this.mouseOriginalX;
+      if (Math.abs(mouseDifference) < 5 && event.button == 0) {
+        this.launchbarItemClicked(item);
+      } else if (!this.pluginsDataService.isPinnedPlugin(item)) {
+        // The remaining logic assumes a pinned plugin, and messes up when the item is
+        // not pinned, so, if the plugin is not pinned, jump out here.
+        return;
+      } else {
+        this.moving = false;
+      }
+      if (event.button == 0 && Math.abs(mouseDifference) > 30) {
+        if(mouseDifference > 0 ) {
+          mouseDifference += 30;
+        } else {
+          mouseDifference += 75;
+        }
+        let offset = Math.floor((mouseDifference)/60);
+        let pluginArray: string[] = [];
+        this.pluginsDataService.pinnedPlugins.forEach(item => pluginArray.push(item.plugin.getBasePlugin().getIdentifier()));
+        let index = pluginArray.indexOf(item.plugin.getBasePlugin().getIdentifier());
+        if (pluginArray.length > 0) {
+          this.pluginsDataService.arrayMove(pluginArray, index, index+offset);
+        }
+      } else if(event.button == 0 && Math.abs(mouseDifference) > 5) {
+        this.pluginsDataService.refreshPinnedPlugins();
+      }
+      (<HTMLImageElement>event.target).style.zIndex = '7';
+      this.currentEvent = null;
+      this.currentItem = null;
+  }
+
+  onMouseMoveContainer(event: MouseEvent): void {
+    let widgetEnd = document.getElementsByClassName("launch-widget")[0].clientWidth;
+    let clockStart = window.innerWidth - document.getElementsByClassName("launchbar-clock")[0].clientWidth;
+    if (this.moving) {
+      if (this.currentEvent != undefined){
+        this.newPosition = Math.floor(((<HTMLImageElement>this.currentEvent).getBoundingClientRect().left - this.originalX)/60);
+        if (event.clientX > widgetEnd + 30 && event.clientX < clockStart - 65){
+          (<HTMLImageElement>this.currentEvent).style.position = 'absolute';
+          (<HTMLImageElement>this.currentEvent).style.left = (event.clientX - 30) + 'px';
+        } else if (event.clientX < widgetEnd) {
+          (<HTMLImageElement>this.currentEvent).style.left = widgetEnd + 'px';
+        } else if (event.clientX > clockStart - 35) {
+          (<HTMLImageElement>this.currentEvent).style.left = (clockStart - 65) + 'px';
+        }
+      }
+    }
   }
 }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-item.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-item.ts
@@ -15,7 +15,6 @@ import { DesktopPluginDefinitionImpl } from 'app/plugin-manager/shared/desktop-p
 export abstract class LaunchbarItem {
   abstract readonly label: string;
   abstract readonly image: string | null;
-  abstract readonly pinned: boolean;
   abstract readonly plugin: DesktopPluginDefinitionImpl;
   abstract readonly launchMetadata: any;
 }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
@@ -11,7 +11,6 @@
 */
 
 import { DesktopPluginDefinitionImpl } from 'app/plugin-manager/shared/desktop-plugin-definition';
-
 import { LaunchbarItem } from '../launchbar-item';
 
 export class PluginLaunchbarItem extends LaunchbarItem {
@@ -21,17 +20,13 @@ export class PluginLaunchbarItem extends LaunchbarItem {
     super();
   }
 
+
   get label(): string {
     return this.plugin.label;
   }
 
   get image(): string | null {
     return this.plugin.image;
-  }
-
-  get pinned(): boolean {
-    // TODO: integrate with config service
-    return this.plugin.hasWebContent;
   }
 
   get launchMetadata(): any {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/services/plugins-data.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/services/plugins-data.service.ts
@@ -1,0 +1,142 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+import { Injectable, Inject } from '@angular/core';
+import { Http, Headers, RequestOptions } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/catch';
+import { LaunchbarItem } from '../launchbar/shared/launchbar-item';
+import { PluginLaunchbarItem } from '../launchbar/shared/launchbar-items/plugin-launchbar-item';
+import { DesktopPluginDefinitionImpl } from '../../../plugin-manager/shared/desktop-plugin-definition';
+import { ContextMenuItem } from 'pluginlib/inject-resources';
+
+@Injectable()
+export class PluginsDataService {
+    public counter: number;
+    public pinnedPlugins: LaunchbarItem[];
+    private scope: string = "user";
+    private resourcePath: string = "ui/launchbar/plugins";
+    private fileName: string = "pinnedPlugins.json" 
+
+    constructor(
+        @Inject(MVDHosting.Tokens.PluginManagerToken) public pluginManager: MVDHosting.PluginManagerInterface,
+        private http: Http,
+    ) { 
+        this.refreshPinnedPlugins;
+        this.counter = 0;
+    }
+
+    public refreshPinnedPlugins(): void {
+      this.pinnedPlugins = [];
+      this.getResource("user", "ui/launchbar/plugins" , "pinnedPlugins.json")
+      .subscribe(res =>{
+        res.json().contents.plugins.forEach((p: string) => {
+          this.pluginManager.findPluginDefinition(p)
+          .then(res => {
+            if (res == null) {
+              console.log("Bad Plugin Definition")
+            } else { 
+              this.pinnedPlugins.push(new PluginLaunchbarItem(res as DesktopPluginDefinitionImpl));
+            }
+          })
+        })
+      })
+    }
+
+    public getResource(scope: string, resourcePath: string, fileName: string): Observable<any>{
+        let uri = RocketMVD.uriBroker.pluginConfigForScopeUri(RocketMVD.PluginManager.getDesktopPlugin(), scope, resourcePath, fileName);
+        let headers = new Headers({ 'Content-Type': 'application/json' });
+        let options = new RequestOptions({ headers: headers });
+        return this.http.get(uri, options);
+    
+      }
+
+    public saveResource(plugins: string[], scope: string, resourcePath: string, fileName: string): Observable<any>{
+        let uri = RocketMVD.uriBroker.pluginConfigForScopeUri(RocketMVD.PluginManager.getDesktopPlugin(), scope, resourcePath, fileName);
+        let params = {"plugins": plugins};
+        return this.http.put(uri, params);
+      }
+
+    public isPinnedPlugin(item: LaunchbarItem): boolean{
+      const itemIdentifier: string = item.plugin.getBasePlugin().getIdentifier();
+      let foundPlugin = this.pinnedPlugins.find(function(launchbarItem: LaunchbarItem): boolean {
+        return launchbarItem.plugin.getBasePlugin().getIdentifier() == itemIdentifier;
+      });
+      if (foundPlugin != undefined) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    public saveToConfigServer(item: LaunchbarItem): void {
+      this.getResource(this.scope, this.resourcePath, this.fileName)
+        .subscribe(res=>{
+          let plugins:string[];
+          if (res.status === 204) {
+            plugins = [];
+          } else {
+            plugins = res.json().contents.plugins;
+          }
+          plugins.push(item.plugin.getBasePlugin().getIdentifier());
+          this.saveResource(plugins, this.scope, this.resourcePath, this.fileName)
+            .subscribe(resp=> {
+              this.refreshPinnedPlugins();
+            })
+        })
+    }
+  
+    public removeFromConfigServer(item: LaunchbarItem): void {
+      this.getResource(this.scope, this.resourcePath, this.fileName)
+      .subscribe(res=>{
+        let index = res.json().contents.plugins.indexOf(item.plugin.getBasePlugin().getIdentifier());
+        let plugins = res.json().contents.plugins;
+        if (index != -1) {
+          plugins.splice(index, 1);
+          this.saveResource(plugins, this.scope, this.resourcePath, this.fileName)
+          .subscribe(res=>{
+            this.refreshPinnedPlugins();
+          })
+        }
+      })
+    }
+
+  public pinContext(item: LaunchbarItem): ContextMenuItem {
+    return {
+      "text": this.isPinnedPlugin(item) ? 'Unpin from taskbar' : 'Pin to taskbar',
+      "action": () => this.isPinnedPlugin(item) ? this.removeFromConfigServer(item) : this.saveToConfigServer(item)
+    };
+  }
+
+  public arrayMove(arr: string[], fromIndex: number, toIndex: number): void{
+    if (toIndex > arr.length) {
+      toIndex = arr.length;
+    } else if(toIndex < 0) {
+      toIndex = 0;
+    }
+    var element = arr[fromIndex];
+    arr.splice(fromIndex, 1);
+    arr.splice(toIndex, 0, element);
+    this.saveResource(arr, this.scope, this.resourcePath, this.fileName)
+    .subscribe(res => {
+      this.refreshPinnedPlugins();
+    })
+  }
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window-pane/window-pane.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window-pane/window-pane.component.html
@@ -11,10 +11,6 @@
 -->
 
 <div class="window-pane">
-  <ng-container *ngIf="contextMenuDef != null">
-    <com-rs-mvd-context-menu [xPos]="contextMenuDef.xPos" [yPos]="contextMenuDef.yPos" [menuItems]="contextMenuDef.items" (complete)="closeContextMenu()"></com-rs-mvd-context-menu>
-  </ng-container>
-
   <div *ngFor="let window of windows">
     <rs-com-mvd-window [desktopWindow]="window"></rs-com-mvd-window>
   </div>


### PR DESCRIPTION
Context menu on icon on launchbar and start menu to pin/unpin. Can drag 'pinned' icons. Icons appended to launchbar for running unpinned plugins.

Still need to more improvements, including:
1. Make the drag-moving experience more polished (e.g., move the other icons gradually, leave an empty space in the launchbar while dragging one of the items)
2. Make a visual distinction between pinned and unpinned icons in the launchbar (e.g., by putting in a separator)
3. Tidy up the implementation code inside launchbar.component.ts (at the very least, clean up a lot of the "magic constants")

Signed-off-by: Robert Penny <rpenny@rocketsoftware.com>