### PR TITLE
Work to support use of ngx-i18n

### DIFF
--- a/virtual-desktop/plugin-config/tsconfig.i18n.json
+++ b/virtual-desktop/plugin-config/tsconfig.i18n.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "pluginlib/*": [
+        "./src/pluginlib/*"
+      ],
+      "@angular/core": [
+        "node_modules/@angular/core"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
 Current example of trying to use ngx-i18n will be pushed shortly to zlux-workflow (along with
supporting pushes to zlux-widgets and zlux-grid).

In the current usage, ngx-i18n mysteriously fails to find
@angular/core, with the message:

: Error: Could not resolve module @angular/core
    at StaticSymbolResolver.getSymbolByModule
    (C:\repos\giza1\zlux\zlux-workflow\node_modules\@angular\compiler\bundles\compiler.umd.js:19499:34)
    etc.

The workaround is to provide the path to @angular/core in the "paths"
in the "compilerOptions".

The  "pluginlib/*" entry is standard for zlux plugins.

This "special" tsconfig.i18n.json is kept separate from tsconfig.base.json, and
provides a "parallel inheritance" of tsconfigs specifically for
supporting the use of ng-xi18n.

We are still investigating how to avoid this workaround. It may not
be necessary for all plugins.