### PR TITLE
Ensure Popper.js is available to bootstrap in externals

### DIFF
--- a/virtual-desktop/plugin-config/webpack.base.js
+++ b/virtual-desktop/plugin-config/webpack.base.js
@@ -85,7 +85,7 @@ var config = {
   },
   'externals': [
     function(context, request, callback) {
-      if (/(@angular)|(^bootstrap$)|(^jquery$)|(^rxjs\/Rx$)/.test(request)){
+      if (/(@angular)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs\/Rx$)/.test(request)){
         return callback(null, {
           commonjs: request,
           commonjs2: request,

--- a/virtual-desktop/src/externals-main.ts
+++ b/virtual-desktop/src/externals-main.ts
@@ -12,7 +12,21 @@
 
 /* Load globals */
 import 'script-loader!jquery';
-import 'script-loader!bootstrap';
+/*
+ Action dropdown in zlux-workflow Workflow tab fails due to lack of Popper.js
+ The following seemed to be the best way to follow the advice in the top answer to
+ https://stackoverflow.com/questions/45680644/angular-4-bootstrap-dropdown-require-popper-js
+ NOTES
+ 1. simple 'script-loader!popper.js loads, for some reason, ../node_modules/popper.js/dist/esm/popper.js
+    This results in:
+   main.js:1 [Script Loader] SyntaxError: Unexpected token export
+    at eval (<anonymous>)
+    at t.exports (main.js:1)
+    at Object../node_modules/script-loader/index.js!./node_modules/popper.js/dist/esm/popper.js (main.js:1)
+ 2. using exports-loader!popper.js to be compatible with esm/popper.js is not compatible with bootstrap: you still get
+   VM4398:1553 Uncaught TypeError: Bootstrap dropdown require Popper.js (https://popper.js.org)
+*/
+import 'script-loader!../node_modules/popper.js/dist/umd/popper.js';import 'script-loader!bootstrap';
 
 /* Load second stage with requirejs */
 const script = document.createElement('script');

--- a/virtual-desktop/webpack.config.js
+++ b/virtual-desktop/webpack.config.js
@@ -92,7 +92,7 @@ module.exports = {
   },
   "externals": [
     function(context, request, callback) {
-      if (/(@angular)|(^bootstrap$)|(^jquery$)|(^rxjs\/Rx$)/.test(request)){
+      if (/(@angular)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs\/Rx$)/.test(request)){
         return callback(null, {
           commonjs: request,
           commonjs2: request,


### PR DESCRIPTION
Upgrading to bootstrap 4 (done along with upgrade to Angular 6)
seemed to expose some need to load Popper.js explicitly.

This commit (as indicated by comment in externals-main.js)
is an interpretation of advice from stack-overflow.

Signed-off-by: Robert Penny <rpenny@rocketsoftware.com>