### PR TITLE
MVD->Zowe Desktop

### DIFF
--- a/bootstrap/webpack.config.js
+++ b/bootstrap/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = {
     // new NoEmitOnErrorsPlugin(),
     new ProgressPlugin(),
     new HtmlWebpackPlugin({
-      "title": "Mainframe Virtual Desktop"
+      "title": "Zowe Desktop"
     })
   ],
   "node": {


### PR DESCRIPTION
Tab still said Mainframe Virtual Desktop, but Zowe Desktop is most correct

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>