### PR TITLE
Show Zowe version on Log in page/Log out pop-up

### DIFF
--- a/virtual-desktop/src/app/authentication-manager/login/login.component.css
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.css
@@ -129,6 +129,12 @@
   color: #474747;
 }
 
+.login-plugin-version {
+  font-family: 'Roboto';
+  font-size: 16px;
+  color: #47474785;
+}
+
 .login-click-blocker {
   position: fixed;
   height: 100%;

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.html
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.html
@@ -34,7 +34,9 @@
             [disabled]="locked">
       <span class="login-button-icon"></span>
       <br>
-      <span class="login-label" i18n="button title|Title of Login button@@login-button-title">Login</span>
+      <span class="login-label" i18n="button title|Title of Login button@@login-button-title">Log in</span>
+      <br><br>
+      <span class="login-plugin-version">{{getPluginVersion()}}</span>
     </button>
   </div>
   </div>

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -20,6 +20,7 @@ import { TranslationService } from 'angular-l10n';
   styleUrls: [ 'login.component.css' ]
 })
 export class LoginComponent implements OnInit {
+  private readonly plugin: any = ZoweZLUX.pluginManager.getDesktopPlugin();
   logo: string = require('../../../assets/images/login/Zowe_Logo.png');
   isLoading:boolean;
   needLogin:boolean;
@@ -121,6 +122,10 @@ export class LoginComponent implements OnInit {
         this.isLoading = false;
       }
     );
+  }
+
+  getPluginVersion(): string | null {
+    return "v. " + this.plugin.version;
   }
 }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.css
@@ -67,7 +67,7 @@
 }
 
 .btn.btn-primary.launchbar-button{
-  margin-left: 15px;
+  width: 100%
 }
 
 .launch-user-caret {
@@ -77,7 +77,7 @@
 }
 
 .launchbar-username {
-  margin-left: 20px;
+  text-align: center;
 }
 
 .launchbar-seperator {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.css
@@ -52,7 +52,7 @@
   right: 0;
   border-top-left-radius: 10px;
   background: #dde8f1;
-  padding: 15px 30px;
+  padding: 10px 15px;
   z-index: 7;
 }
 
@@ -60,10 +60,24 @@
   display: none;
 }
 
+.launchbar-plugin-version {
+  font-size: smaller;
+  margin-top: 5px;
+  color: #3333337d;
+}
+
+.btn.btn-primary.launchbar-button{
+  margin-left: 15px;
+}
+
 .launch-user-caret {
   position: absolute;
   bottom: 70px;
   right: 10px;
+}
+
+.launchbar-username {
+  margin-left: 20px;
 }
 
 .launchbar-seperator {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.html
@@ -22,10 +22,10 @@
 
 <div class="launchbar-user-popup" [class.hidden]="!popupVisible">
   <h5 class="launchbar-username">{{getUsername()}}</h5>
-  <h6 class="launchbar-plugin-version">{{getPluginVersion()}}</h6>
   <button #logoutbutton class="btn btn-primary launchbar-button" (click)="logout()"
     i18n="signout button|Title of Sign out button@@signout-button-title"
   >Log out</button>
+  <h6 class="launchbar-plugin-version">{{getPluginVersion()}}</h6>
   <!-- Convenience widgets for testing the i18n work in https://github.com/zowe/zlux-app-manager/issues/10
     Once there is a better UI, we can delete this commented-out code:
   <button #languagebutton class="btn btn-primary launchbar-button" (click)="setLanguage('fr')">French</button>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.html
@@ -22,9 +22,10 @@
 
 <div class="launchbar-user-popup" [class.hidden]="!popupVisible">
   <h5 class="launchbar-username">{{getUsername()}}</h5>
+  <h6 class="launchbar-plugin-version">{{getPluginVersion()}}</h6>
   <button #logoutbutton class="btn btn-primary launchbar-button" (click)="logout()"
     i18n="signout button|Title of Sign out button@@signout-button-title"
-  >Sign Out</button>
+  >Log out</button>
   <!-- Convenience widgets for testing the i18n work in https://github.com/zowe/zlux-app-manager/issues/10
     Once there is a better UI, we can delete this commented-out code:
   <button #languagebutton class="btn btn-primary launchbar-button" (click)="setLanguage('fr')">French</button>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts
@@ -31,6 +31,7 @@ import { LanguageLocaleService } from '../../../../i18n/language-locale.service'
   providers: [LanguageLocaleService]
 })
 export class LaunchbarWidgetComponent implements OnInit {
+  private readonly plugin: any = ZoweZLUX.pluginManager.getDesktopPlugin();
   date: Date;
   popupVisible: boolean;
   @Output() popupStateChanged = new EventEmitter<boolean>();
@@ -61,6 +62,10 @@ export class LaunchbarWidgetComponent implements OnInit {
 
   getUsername(): string | null {
     return this.authenticationManager.getUsername();
+  }
+
+  getPluginVersion(): string | null {
+    return "v. " + this.plugin.version;
   }
 
   logout(): void {

--- a/virtual-desktop/src/assets/i18n/messages.fr.xlf
+++ b/virtual-desktop/src/assets/i18n/messages.fr.xlf
@@ -29,7 +29,7 @@
         <note priority="1" from="meaning">label</note>
       </trans-unit>
       <trans-unit id="login-button-title" datatype="html">
-        <source>Login</source><target state="new">Identification</target>
+        <source>Log in</source><target state="new">Me connecter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authentication-manager/login/login.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -38,14 +38,11 @@
         <note priority="1" from="meaning">button title</note>
       </trans-unit>
       <trans-unit id="signout-button-title" datatype="html">
-        <source>Sign Out</source><target state="new">Déconnexion</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts</context>
-          <context context-type="linenumber">27</context>
-        </context-group>
+        <source>Log out</source><target state="new">Déconnexion</target>
+        
         <note priority="1" from="description">Title of Sign out button</note>
         <note priority="1" from="meaning">signout button</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts</context><context context-type="linenumber">28</context></context-group></trans-unit>
     </body>
   </file>
 </xliff>

--- a/virtual-desktop/src/assets/i18n/messages.ja.xlf
+++ b/virtual-desktop/src/assets/i18n/messages.ja.xlf
@@ -29,7 +29,7 @@
         <note priority="1" from="meaning">label</note>
       </trans-unit>
       <trans-unit id="login-button-title" datatype="html">
-        <source>Login</source><target state="new">ログイン</target>
+        <source>Log in</source><target state="new">ログイン</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authentication-manager/login/login.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -38,14 +38,11 @@
         <note priority="1" from="meaning">button title</note>
       </trans-unit>
       <trans-unit id="signout-button-title" datatype="html">
-        <source>Sign Out</source><target state="new">サインアウト</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts</context>
-          <context context-type="linenumber">27</context>
-        </context-group>
+        <source>Log out</source><target state="new">ログアウト</target>
+        
         <note priority="1" from="description">Title of Sign out button</note>
         <note priority="1" from="meaning">signout button</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts</context><context context-type="linenumber">28</context></context-group></trans-unit>
     </body>
   </file>
 </xliff>

--- a/virtual-desktop/src/assets/i18n/messages.ru.xlf
+++ b/virtual-desktop/src/assets/i18n/messages.ru.xlf
@@ -27,7 +27,7 @@
         <note priority="1" from="description">Label for password</note>
         <note priority="1" from="meaning">label</note>
       </trans-unit><trans-unit id="login-button-title" datatype="html">
-        <source>Login</source><target state="new">Войти</target>
+        <source>Log in</source><target state="new">Войти</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authentication-manager/login/login.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -35,14 +35,11 @@
         <note priority="1" from="description">Title of Login button</note>
         <note priority="1" from="meaning">button title</note>
       </trans-unit><trans-unit id="signout-button-title" datatype="html">
-        <source>Sign Out</source><target state="new">Выйти</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts</context>
-          <context context-type="linenumber">27</context>
-        </context-group>
+        <source>Log out</source><target state="new">Выйти</target>
+        
         <note priority="1" from="description">Title of Sign out button</note>
         <note priority="1" from="meaning">signout button</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts</context><context context-type="linenumber">28</context></context-group></trans-unit>
     </body>
   </file>
 </xliff>

--- a/virtual-desktop/src/assets/i18n/messages.xlf
+++ b/virtual-desktop/src/assets/i18n/messages.xlf
@@ -30,7 +30,7 @@
         <note priority="1" from="meaning">label</note>
       </trans-unit>
       <trans-unit id="login-button-title" datatype="html">
-        <source>Login</source>
+        <source>Log in</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/authentication-manager/login/login.component.ts</context>
           <context context-type="linenumber">37</context>
@@ -39,10 +39,10 @@
         <note priority="1" from="meaning">button title</note>
       </trans-unit>
       <trans-unit id="signout-button-title" datatype="html">
-        <source>Sign Out</source>
+        <source>Log out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">28</context>
         </context-group>
         <note priority="1" from="description">Title of Sign out button</note>
         <note priority="1" from="meaning">signout button</note>


### PR DESCRIPTION
1) Shows Zowe infrastructure version information on the Log in page and Log out pop-up

2) Standardized "Sign Out" into "Log out" and "Login" into "Log in" as per UI design suggestions

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>