### PR TITLE
Use requirejs 0 second timeout to avoid high latency timeouts

### DIFF
--- a/virtual-desktop/src/externals.ts
+++ b/virtual-desktop/src/externals.ts
@@ -13,7 +13,6 @@
 /*
   Imperfect solution to an imperfect world. See https://github.com/requirejs/requirejs/issues/787 and https://requirejs.org/docs/api.html#config-waitSeconds
 */
-console.log("I set that config");
 (window as any).requirejs.config({
   waitSeconds: 0
 });

--- a/virtual-desktop/src/externals.ts
+++ b/virtual-desktop/src/externals.ts
@@ -10,6 +10,14 @@
   Copyright Contributors to the Zowe Project.
 */
 
+/*
+  Imperfect solution to an imperfect world. See https://github.com/requirejs/requirejs/issues/787 and https://requirejs.org/docs/api.html#config-waitSeconds
+*/
+console.log("I set that config");
+(window as any).requirejs.config({
+  waitSeconds: 0
+});
+
 /* These will be packaged into a single bundle by the webpack bundling system.
  * We then expose them to our module loader (requirejs) manually and use that
  * to load the desktop and external plugins. These requires use webpack. */


### PR DESCRIPTION
If you are on a high latency connection, the Desktop or Apps can fail to load due to requirejs having a default timeout value of 7 seconds. That is, if a file doesnt load in 7 seconds, requirejs gives up on it and leaves you with a dead page. See https://github.com/requirejs/requirejs/issues/787 and https://requirejs.org/docs/api.html#config-waitSeconds

Setting the timeout value to 0 disables it. This commit does not include any new way to indicate to the users that the page is still loading, but will allow the page to load where it would previously not.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>