### PR TITLE
Cascading windows/Remembering window positions

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -106,13 +106,16 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     let { width: dtWindowWidth, height: dtWindowHeight } = plugin.defaultWindowStyle;
     const rightMostPosition = innerWidth - dtWindowWidth;
     const bottomMostPosition = innerHeight - dtWindowHeight;
-
+    let desktopHeight = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().bottom;
+    let desktopWidth = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().right;
+    let launchbarHeight = document.getElementsByClassName("launchbar-container")[0].clientHeight;
     const pluginId = plugin.getIdentifier();
     if (this.windowPositionsMap.has(pluginId))//If a plugin has previously saved window position & size data
     { return {
         ...this.windowPositionsMap.get(pluginId),
       } as WindowPosition
     }
+    /*
 
     let valueArray = Array.from(this.runningPluginMap.values());
     let missingIndex = 0;
@@ -124,9 +127,12 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         missingIndex++;
       }
     }
+    */
 
-    let nextLeft = WindowManagerService.NEW_WINDOW_POSITION_INCREMENT * (missingIndex + 1);
-    let nextTop = WindowManagerService.NEW_WINDOW_POSITION_INCREMENT * (missingIndex + 1);
+    let nextLeft = (desktopWidth / 2) - (dtWindowWidth / 2);
+    let nextTop = (desktopHeight / 2) - (dtWindowHeight / 2) - (WindowManagerService.WINDOW_HEADER_HEIGHT / 2) - (launchbarHeight / 2);
+    //let nextLeft = WindowManagerService.NEW_WINDOW_POSITION_INCREMENT * (missingIndex + 1);
+    //let nextTop = WindowManagerService.NEW_WINDOW_POSITION_INCREMENT * (missingIndex + 1);
 
     // Find best next starting position
     if (nextLeft > rightMostPosition) { // Start over both top and left

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -63,13 +63,13 @@ export class WindowComponent {
     if (position.left + position.width - WINDOW_HEADER_HEIGHT < 0) {
       position.left = -position.width + WINDOW_HEADER_HEIGHT;
     }
-    var positionBottom = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().bottom;
-    var positionRight = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().right;
-    if ((position.top + WINDOW_HEADER_HEIGHT) > positionBottom) {
-      position.top = positionBottom - WINDOW_HEADER_HEIGHT;
+    let desktopHeight = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().bottom;
+    let desktopWidth = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().right;
+    if ((position.top + WINDOW_HEADER_HEIGHT) > desktopHeight) {
+      position.top = desktopHeight - WINDOW_HEADER_HEIGHT;
     }
-    if ((position.left + WINDOW_HEADER_HEIGHT) > positionRight) {
-      position.left = positionRight - WINDOW_HEADER_HEIGHT;
+    if ((position.left + WINDOW_HEADER_HEIGHT) > desktopWidth) {
+      position.left = desktopWidth - WINDOW_HEADER_HEIGHT;
     }
 
     return {


### PR DESCRIPTION
1. This PR solves the bug where opening and closing the same plugin will move the newly opened window farther and farther down the page (in a cascade-type fashion). This was caused by a cascade logic that relied on "last opened window", which can be unreliable at times (for ex. if the last opened window happens to be the same plugin).

Instead, the cascade now works by using an index, so 
for ex. if I opened plugins A, B, C, 

      ___ A ________
     |        ___ B ________
     |       |        ___ C ________ 
             |       |
                     |

then closed B

      ___ A ________
     |        
     |                ___ C ________ 
                     |
                     |

then opened plugin D, I would get

      ___ A ________
     |        ___ D ________
     |       |        ___ C ________ 
             |       |
                     |
As each plugin will move down via cascade, with plugins filling up available slots.

2. This PR makes it so that Zowe remembers the positions of user's previously opened plugins. So if a user last closed a plugin at a certain position, with a certain size, it will pop back up with that same size in the same desired position.

In case, the plugin window is too large to move farther down the cascade, the behavior is the same as prior to the PR.

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>