### PR TITLE
Fix for an issue when there is a missing translation file in a chain of fallbacks

### DIFF
--- a/virtual-desktop/src/app/i18n/i18n.module.ts
+++ b/virtual-desktop/src/app/i18n/i18n.module.ts
@@ -12,9 +12,19 @@ import { NgModule, APP_INITIALIZER, LOCALE_ID, Inject } from '@angular/core';
 import { LanguageLocaleService } from './language-locale.service';
 import { localeInitializer, localeIdFactory } from './locale-initializer.provider';
 import { HttpClientModule } from '@angular/common/http';
-import { TranslationModule, TRANSLATION_CONFIG, LocaleConfig, ISOCode, L10nLoader, TranslationConfig, LOCALE_CONFIG } from 'angular-l10n';
+import {
+  HttpTranslationProvider,
+  ISOCode,
+  L10nLoader,
+  LOCALE_CONFIG,
+  LocaleConfig,
+  TRANSLATION_CONFIG,
+  TranslationConfig,
+  TranslationModule
+} from 'angular-l10n';
 import { L10nStorageService } from './l10n-storage.service';
 import { L10nConfigService } from './l10n-config.service';
+import { L10nCustomTranslationProvider } from './l10n-custom-translation.provider';
 
 @NgModule({
   imports: [
@@ -26,12 +36,17 @@ import { L10nConfigService } from './l10n-config.service';
         composedLanguage: [ISOCode.Language, ISOCode.Country],
         caching: true
       }},
-      { localeStorage: L10nStorageService }
+      {
+        localeStorage: L10nStorageService,
+        translationProvider: L10nCustomTranslationProvider
+      }
     )
   ],
   providers: [
     L10nConfigService,
     L10nStorageService,
+    HttpTranslationProvider,
+    L10nCustomTranslationProvider,
     { provide: LOCALE_ID, useFactory: localeIdFactory, deps: [LanguageLocaleService]},
     {
       provide: APP_INITIALIZER,

--- a/virtual-desktop/src/app/i18n/l10n-custom-translation.provider.ts
+++ b/virtual-desktop/src/app/i18n/l10n-custom-translation.provider.ts
@@ -18,15 +18,16 @@ import { TranslationProvider, HttpTranslationProvider } from 'angular-l10n';
 
     constructor(private provider: HttpTranslationProvider) { }
 
-    public getTranslation(language: string, args: any): Observable<any> {
-      /*
-        Angular-l10n algorithm that merges translation files leads to unexpected behavior
-        if there is a missing translation file in a chain of fallbacks, e.g.:
-          if messages.es.json is missing in a chain [ messages.es-ES.json -> messages.es.json -> messages.en.json ]
-          it uses translations from  messages.en.json.
-        An empty object solves the issue in case of a missing translation file.
-      */
-      return this.provider.getTranslation(language, args).pipe(catchError(() => of({})));
+  public getTranslation(language: string, args: any): Observable<any> {
+    /*
+      Angular-l10n algorithm that merges translation files leads to unexpected behavior
+      if there is a missing translation file in a chain of fallbacks, e.g.:
+        if messages.es.json is missing in a chain
+          [ messages.es-ES.json -> messages.es.json -> messages.en.json ]
+        it will use translations from  messages.en.json.
+      An empty object solves the issue in case of a missing translation file.
+    */
+    return this.provider.getTranslation(language, args).pipe(catchError(() => of({})));
   }
 
 }

--- a/virtual-desktop/src/app/i18n/l10n-custom-translation.provider.ts
+++ b/virtual-desktop/src/app/i18n/l10n-custom-translation.provider.ts
@@ -1,0 +1,41 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { TranslationProvider, HttpTranslationProvider } from 'angular-l10n';
+
+@Injectable() export class L10nCustomTranslationProvider implements TranslationProvider {
+
+    constructor(private provider: HttpTranslationProvider) { }
+
+    public getTranslation(language: string, args: any): Observable<any> {
+      /*
+        Angular-l10n algorithm that merges translation files leads to unexpected behavior
+        if there is a missing translation file in a chain of fallbacks, e.g.:
+          if messages.es.json is missing in a chain [ messages.es-ES.json -> messages.es.json -> messages.en.json ]
+          it uses translations from  messages.en.json.
+        An empty object solves the issue in case of a missing translation file.
+      */
+      return this.provider.getTranslation(language, args).pipe(catchError(() => of({})));
+  }
+
+}
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/


### PR DESCRIPTION
Angular-l10n algorithm that merges translation files leads to unexpected behavior if there is a missing translation file in a chain of fallbacks, e.g.:
if messages.es.json is missing in a chain `[ messages.es-ES.json -> messages.es.json -> messages.en.json ]` it uses translations from messages.en.json. An empty object solves the issue in case of a missing translation file. 
Fixes #27

