### PR TITLE
Remove open windows and items from launchbar on logout

### DIFF
--- a/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
+++ b/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
@@ -10,7 +10,7 @@
   Copyright Contributors to the Zowe Project.
 */
 
-import { Injectable, EventEmitter } from '@angular/core';
+import { Injectable, Injector, EventEmitter } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
@@ -24,7 +24,8 @@ export class AuthenticationManager {
   private log: ZLUX.ComponentLogger;
   
   constructor(
-    public http: Http
+    public http: Http,
+    private injector: Injector
   ) {
     //TODO: Find a way to get the logger in a more formal manner if possible
     this.log = ZoweZLUX.logger.makeComponentLogger("com.rs.mvd.ng2desktop.authentication");
@@ -88,6 +89,8 @@ export class AuthenticationManager {
   }
 
   requestLogout(): void {
+    const windowManager: MVDWindowManagement.WindowManagerServiceInterface = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
+    windowManager.closeAllWindows();
     this.performLogout().subscribe(
       response => {
         this.requestLogin();

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -28,21 +28,21 @@ import { TranslationService } from 'angular-l10n';
   providers: [PluginsDataService]
 })
 export class LaunchbarComponent {
-  allItems: LaunchbarItem[];
+  private allItems: LaunchbarItem[];
   runItems: LaunchbarItem[];
   isActive: boolean;
   contextMenuRequested: Subject<{xPos: number, yPos: number, items: ContextMenuItem[]}>;
   originalX: number;
   mouseOriginalX: number;
   currentEvent: EventTarget | null;
-  currentItem: LaunchbarItem | null;
+  private currentItem: LaunchbarItem | null;
   moving: boolean;
   newPosition: number;
   loggedIn: boolean;
   helperLoggedIn: boolean;
-  pluginManager: MVDHosting.PluginManagerInterface;
-  applicationManager: MVDHosting.ApplicationManagerInterface;
-  authenticationManager: MVDHosting.AuthenticationManagerInterface;
+  private pluginManager: MVDHosting.PluginManagerInterface;
+  private applicationManager: MVDHosting.ApplicationManagerInterface;
+  private authenticationManager: MVDHosting.AuthenticationManagerInterface;
   propertyWindowPluginDef : DesktopPluginDefinitionImpl;
   
    constructor(
@@ -51,18 +51,18 @@ export class LaunchbarComponent {
     public windowManager: WindowManagerService,
     private translation: TranslationService
   ) {
-    // Workaround for AoT problem with namespaces (see angular/angular#15613)
-    this.pluginManager = this.injector.get(MVDHosting.Tokens.PluginManagerToken);
-    this.applicationManager = this.injector.get(MVDHosting.Tokens.ApplicationManagerToken);
-    this.authenticationManager = this.injector.get(MVDHosting.Tokens.AuthenticationManagerToken);
-    this.allItems = [];
-    this.runItems = [];
-    this.isActive = false;
-    this.contextMenuRequested = new Subject();
-    this.loggedIn = false;
-    this.helperLoggedIn = false; //helperLoggedIn is to indicate when the initial login happens
-  }
-
+     // Workaround for AoT problem with namespaces (see angular/angular#15613)
+     this.pluginManager = this.injector.get(MVDHosting.Tokens.PluginManagerToken);
+     this.applicationManager = this.injector.get(MVDHosting.Tokens.ApplicationManagerToken);
+     this.authenticationManager = this.injector.get(MVDHosting.Tokens.AuthenticationManagerToken);
+     this.allItems = [];
+     this.runItems = [];
+     this.isActive = false;
+     this.contextMenuRequested = new Subject();
+     this.loggedIn = false;
+     this.helperLoggedIn = false; //helperLoggedIn is to indicate when the initial login happens
+   }
+  
   ngOnInit(): void {
     this.allItems = [];
     this.pluginManager.loadApplicationPluginDefinitions().then(pluginDefinitions => {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/services/plugins-data.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/services/plugins-data.service.ts
@@ -19,24 +19,32 @@ import { ContextMenuItem } from 'pluginlib/inject-resources';
 import { TranslationService } from 'angular-l10n';
 
 @Injectable()
-export class PluginsDataService {
-    public counter: number;
-    public pinnedPlugins: LaunchbarItem[];
-    private scope: string = "user";
-    private resourcePath: string = "ui/launchbar/plugins";
-    private fileName: string = "pinnedPlugins.json"
-    private pluginManager: MVDHosting.PluginManagerInterface;
+export class PluginsDataService implements MVDHosting.LogoutActionInterface {
+  public counter: number;
+  public pinnedPlugins: LaunchbarItem[];
+  private scope: string = "user";
+  private resourcePath: string = "ui/launchbar/plugins";
+  private fileName: string = "pinnedPlugins.json"
+  private pluginManager: MVDHosting.PluginManagerInterface;
+  private authenticationManager: MVDHosting.AuthenticationManagerInterface;
 
-    constructor(
-        private injector: Injector,
-        private http: Http,
-        private translation: TranslationService
-    ) {
-        // Workaround for AoT problem with namespaces (see angular/angular#15613)
-        this.pluginManager = this.injector.get(MVDHosting.Tokens.PluginManagerToken);
-        this.refreshPinnedPlugins;
-        this.counter = 0;
-    }
+  constructor(
+    private injector: Injector,
+    private http: Http,
+    private translation: TranslationService
+  ) {
+    // Workaround for AoT problem with namespaces (see angular/angular#15613)
+    this.pluginManager = this.injector.get(MVDHosting.Tokens.PluginManagerToken);
+    this.authenticationManager = this.injector.get(MVDHosting.Tokens.AuthenticationManagerToken);
+    this.authenticationManager.registerPreLogoutAction(this);
+    this.refreshPinnedPlugins;
+    this.counter = 0;
+  }
+
+    onLogout(username: string): boolean {
+      this.pinnedPlugins = [];
+      return true;
+  }
 
     public refreshPinnedPlugins(): void {
       this.pinnedPlugins = [];

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -315,6 +315,13 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     }
   }
 
+  closeAllWindows() :void {
+    let windows: DesktopWindow[] = Array.from(this.windowMap.values());
+    windows.forEach((window: DesktopWindow)=> {
+      this.closeWindow(window.windowId);
+    });
+  }
+
   registerCloseHandler(windowId: MVDWindowManagement.WindowId, handler: () => Promise<void>): void {
     const desktopWindow = this.windowMap.get(windowId);
     if (desktopWindow == null) {


### PR DESCRIPTION
Depends on https://github.com/zowe/zlux-platform/pull/13
This fixes a security/UX concern in which if you log out, you can log in as another user, but retain the windows of the old user, giving a mixed experience as to user permission expectations.

How to test this?
Today: login as a user.. open some windows, logout. Do not reload or close the page, but log in as a different user
The bad behavior you see: other user's windows stay open, and launchbar pinned items are retained during logout period too.

With this commit: login as user.. open some windows, logout. Logout destroys windows, and removes pinned items from launchbar.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>