### PR TITLE
Replace "Authentication failed..." message.

### DIFF
--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -63,11 +63,7 @@ export class LoginComponent implements OnInit {
           try {
             const jsonMessage = error.json();
             if (this.isAuthResponseMessage(jsonMessage)) {
-              if (this.isZssConnectionErrorMessage(jsonMessage)) {
-                this.errorMessage = this.translation.translate('FailedToCommunicateWithZssAuthenticationServer');
-              } else {
-                this.errorMessage = this.translation.translate('IncorrectUsernameAndOrPassword');
-              }
+              this.handleAuthResponseMessage(jsonMessage);
             } else {
               this.errorMessage = error.text();
             }
@@ -111,11 +107,7 @@ export class LoginComponent implements OnInit {
         this.needLogin = true;
         const jsonMessage = error.json();
         if (this.isAuthResponseMessage(jsonMessage)) {
-          if (this.isZssConnectionErrorMessage(jsonMessage)) {
-            this.errorMessage = this.translation.translate('FailedToCommunicateWithZssAuthenticationServer');
-          } else {
-            this.errorMessage = this.translation.translate('IncorrectUsernameAndOrPassword');
-          }
+          this.handleAuthResponseMessage(jsonMessage);
         } else {
           this.errorMessage = error.text();
         }
@@ -126,7 +118,15 @@ export class LoginComponent implements OnInit {
     );
   }
 
-  isAuthResponseMessage(message: any): message is AuthResponseMessage {
+  private handleAuthResponseMessage(authMessage: AuthResponseMessage): void {
+    if (this.isZssConnectionErrorMessage(authMessage)) {
+      this.errorMessage = this.translation.translate('FailedToCommunicateWithZssAuthenticationServer');
+    } else {
+      this.errorMessage = this.translation.translate('IncorrectUsernameAndOrPassword');
+    }
+  }
+
+  private isAuthResponseMessage(message: any): message is AuthResponseMessage {
     if (typeof message !== 'object') {
       return false;
     }
@@ -139,7 +139,7 @@ export class LoginComponent implements OnInit {
     return true;
   }
 
-  isZssConnectionErrorMessage(authResponse: AuthResponseMessage): boolean {
+  private isZssConnectionErrorMessage(authResponse: AuthResponseMessage): boolean {
     if (typeof authResponse.categories['zss'] !== 'object') {
       return false;
     }

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -70,8 +70,7 @@ export class LoginComponent implements OnInit {
                   failedTypes.push(keys[i]);
                 }
               }
-              this.errorMessage = this.translation.translate('AuthenticationFailed',
-                { numTypes: failedTypes.length, types: JSON.stringify(failedTypes) });
+              this.errorMessage = this.translation.translate('IncorrectUsernameAndOrPassword');
             }
           } catch (e) {
             this.errorMessage = error;
@@ -121,9 +120,7 @@ export class LoginComponent implements OnInit {
                 failedTypes.push(keys[i]);
               }
             }
-            this.errorMessage = this.translation.translate('AuthenticationFailed',
-              { numTypes: failedTypes.length, types: JSON.stringify(failedTypes) });
-
+            this.errorMessage = this.translation.translate('IncorrectUsernameAndOrPassword');
           }
         } else {
           this.errorMessage = error.text();

--- a/virtual-desktop/src/assets/i18n/messages.en.json
+++ b/virtual-desktop/src/assets/i18n/messages.en.json
@@ -5,7 +5,7 @@
   "Close": "Close",
   "Open": "Open",
   "Properties":"Properties",
-  "AuthenticationFailed": "Authentication failed for {{numTypes}} types. Types: {{types}}",
+  "IncorrectUsernameAndOrPassword": "Incorrect user name and/or password",
   "UsernameRequired": "Username required"
 
 }

--- a/virtual-desktop/src/assets/i18n/messages.en.json
+++ b/virtual-desktop/src/assets/i18n/messages.en.json
@@ -6,6 +6,7 @@
   "Open": "Open",
   "Properties":"Properties",
   "IncorrectUsernameAndOrPassword": "Incorrect user name and/or password",
+  "FailedToCommunicateWithZssAuthenticationServer": "Failed to communicate with zss authentication server",
   "UsernameRequired": "Username required"
 
 }

--- a/virtual-desktop/src/assets/i18n/messages.fr.json
+++ b/virtual-desktop/src/assets/i18n/messages.fr.json
@@ -5,7 +5,7 @@
   "Close": "Fermer",
   "Open": "Ouvrir",
   "Properties":"Propriétés",
-  "AuthenticationFailed": "L'authentification a échoué pour {{numTypes}} types. Les types: {{types}}",
+  "IncorrectUsernameAndOrPassword": "Nom d'utilisateur ou mot de passe incorrect",
   "UsernameRequired": "Nom d'utilisateur requis"
 
 }

--- a/virtual-desktop/src/assets/i18n/messages.fr.json
+++ b/virtual-desktop/src/assets/i18n/messages.fr.json
@@ -6,6 +6,7 @@
   "Open": "Ouvrir",
   "Properties":"Propriétés",
   "IncorrectUsernameAndOrPassword": "Nom d'utilisateur ou mot de passe incorrect",
+  "FailedToCommunicateWithZssAuthenticationServer": "La communication avec le serveur d'authentification zss a échoué",
   "UsernameRequired": "Nom d'utilisateur requis"
 
 }

--- a/virtual-desktop/src/assets/i18n/messages.ja.json
+++ b/virtual-desktop/src/assets/i18n/messages.ja.json
@@ -5,6 +5,6 @@
   "Close": "閉じる",
   "Open": "開く",
   "Properties":"プロパティー",
-  "AuthenticationFailed": "{{numTypes}}個の認証プロバイダー({{types}})に対して認証が失敗しました",
+  "IncorrectUsernameAndOrPassword": "ユーザー名またはパスワードが正しくありません",
   "UsernameRequired": "ユーザー名が必要です"
 }

--- a/virtual-desktop/src/assets/i18n/messages.ja.json
+++ b/virtual-desktop/src/assets/i18n/messages.ja.json
@@ -6,5 +6,6 @@
   "Open": "開く",
   "Properties":"プロパティー",
   "IncorrectUsernameAndOrPassword": "ユーザー名またはパスワードが正しくありません",
+  "FailedToCommunicateWithZssAuthenticationServer": "zss 認証サーバーへの接続に失敗しました",
   "UsernameRequired": "ユーザー名が必要です"
 }

--- a/virtual-desktop/src/assets/i18n/messages.ru.json
+++ b/virtual-desktop/src/assets/i18n/messages.ru.json
@@ -6,5 +6,6 @@
   "Open": "Открыть",
   "Properties": "Свойства",
   "IncorrectUsernameAndOrPassword": "Неверное имя пользователя или пароль",
+  "FailedToCommunicateWithZssAuthenticationServer": "Не удалось связаться с zss-сервером аутентификации",
   "UsernameRequired": "Введите имя пользователя"
 }

--- a/virtual-desktop/src/assets/i18n/messages.ru.json
+++ b/virtual-desktop/src/assets/i18n/messages.ru.json
@@ -5,6 +5,6 @@
   "Close": "Закрыть",
   "Open": "Открыть",
   "Properties": "Свойства",
-  "AuthenticationFailed": "Ошибка аутентификации для {{types}}",
+  "IncorrectUsernameAndOrPassword": "Неверное имя пользователя или пароль",
   "UsernameRequired": "Введите имя пользователя"
 }

--- a/virtual-desktop/src/assets/i18n/messages.zh.json
+++ b/virtual-desktop/src/assets/i18n/messages.zh.json
@@ -6,5 +6,6 @@
   "Open": "打开",
   "Properties":"属性",
   "IncorrectUsernameAndOrPassword": "用户名或密码错误",
+  "FailedToCommunicateWithZssAuthenticationServer": "与zss认证服务器连接失败",
   "UsernameRequired": "用户名不能为空"
 }

--- a/virtual-desktop/src/assets/i18n/messages.zh.json
+++ b/virtual-desktop/src/assets/i18n/messages.zh.json
@@ -5,6 +5,6 @@
   "Close": "关闭",
   "Open": "打开",
   "Properties":"属性",
-  "AuthenticationFailed": "{{numTypes}} 个类型验证失败 类型: {{types}}",
+  "IncorrectUsernameAndOrPassword": "用户名或密码错误",
   "UsernameRequired": "用户名不能为空"
 }


### PR DESCRIPTION
Replace "Authentication failed for 1 types. Types: ["zss"]" with two messages
* Incorrect user name and/or password
* Failed to communicate with zss authentication server

Test steps:
* stop zss-server and try to login - expected error message: Failed to communicate with zss authentication server
* start zss-server and try to login with wrong credentials - expected error message: Incorrect user name and/or password

This PR depends on https://github.com/zowe/zss-auth/pull/5