### PR TITLE
Window Management/Position Saving

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -162,10 +162,10 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         }
     }
 
-    // When cascade has reached too far down or too far to the right, start again from 0,0
+    // When cascade has reached too far down or too far to the right, start again from 1, 1
     if (nextLeft > rightMostPosition || nextTop > (bottomMostPosition - launchbarHeight)) {
-      nextLeft = 0;
-      nextTop = 0;
+      nextLeft = 1;
+      nextTop = 1;
     }
 
     /* We've chosen the best position based on history and requested window size, now we

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -63,8 +63,8 @@ export class WindowComponent {
     if (position.left + position.width - WINDOW_HEADER_HEIGHT < 0) {
       position.left = -position.width + WINDOW_HEADER_HEIGHT;
     }
-    let desktopHeight = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().bottom;
-    let desktopWidth = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().right;
+    let desktopHeight = document.getElementsByClassName('window-pane')[0].clientHeight;
+    let desktopWidth = document.getElementsByClassName('window-pane')[0].clientWidth;
     if ((position.top + WINDOW_HEADER_HEIGHT) > desktopHeight) {
       position.top = desktopHeight - WINDOW_HEADER_HEIGHT;
     }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -63,13 +63,13 @@ export class WindowComponent {
     if (position.left + position.width - WINDOW_HEADER_HEIGHT < 0) {
       position.left = -position.width + WINDOW_HEADER_HEIGHT;
     }
-    var positionBottom = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().bottom;
-    var positionRight = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().right;
-    if ((position.top + WINDOW_HEADER_HEIGHT) > positionBottom) {
-      position.top = positionBottom - WINDOW_HEADER_HEIGHT;
+    let desktopHeight = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().bottom;
+    let desktopWidth = document.getElementsByClassName('window-pane').item(0).getBoundingClientRect().right;
+    if ((position.top + WINDOW_HEADER_HEIGHT) > desktopHeight) {
+      position.top = desktopHeight - WINDOW_HEADER_HEIGHT;
     }
-    if ((position.left + WINDOW_HEADER_HEIGHT) > positionRight) {
-      position.left = positionRight - WINDOW_HEADER_HEIGHT;
+    if ((position.left + WINDOW_HEADER_HEIGHT) > desktopWidth) {
+      position.left = desktopWidth - WINDOW_HEADER_HEIGHT;
     }
 
     return {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -18,7 +18,7 @@ import { WindowPosition } from '../shared/window-position';
 
 const SCREEN_EDGE_BORDER = 2;
 const WINDOW_HEADER_HEIGHT = WindowManagerService.WINDOW_HEADER_HEIGHT;
-const LAUNCHBAR_HEIGHT = 60;
+const LAUNCHBAR_HEIGHT = WindowManagerService.LAUNCHBAR_HEIGHT;
 
 @Component({
   selector: 'rs-com-mvd-window',
@@ -62,19 +62,22 @@ export class WindowComponent {
 
   positionStyle(): any {
     const position = this.getPosition();
+    const DESKTOP_HEIGHT = document.getElementsByClassName('window-pane')[0].clientHeight;
+    const DESKTOP_WIDTH = document.getElementsByClassName('window-pane')[0].clientWidth;
+
+    /* These 4 conditionals check if a window is out of bounds by checking if a window has been
+    dragged too far out of view, in either of the 4 directions, and locks it from going further. */
     if (position.top < 0) {
       position.top = SCREEN_EDGE_BORDER;
     }
     if (position.left + position.width - WINDOW_HEADER_HEIGHT < 0) {
       position.left = -position.width + WINDOW_HEADER_HEIGHT;
     }
-    let desktopHeight = document.getElementsByClassName('window-pane')[0].clientHeight;
-    let desktopWidth = document.getElementsByClassName('window-pane')[0].clientWidth;
-    if ((position.top + WINDOW_HEADER_HEIGHT) > desktopHeight - LAUNCHBAR_HEIGHT) {
-      position.top = desktopHeight - WINDOW_HEADER_HEIGHT - LAUNCHBAR_HEIGHT;
+    if ((position.top + WINDOW_HEADER_HEIGHT) > DESKTOP_HEIGHT - LAUNCHBAR_HEIGHT) {
+      position.top = DESKTOP_HEIGHT - WINDOW_HEADER_HEIGHT - LAUNCHBAR_HEIGHT;
     }
-    if ((position.left + WINDOW_HEADER_HEIGHT) > desktopWidth) {
-      position.left = desktopWidth - WINDOW_HEADER_HEIGHT;
+    if ((position.left + WINDOW_HEADER_HEIGHT) > DESKTOP_WIDTH) {
+      position.left = DESKTOP_WIDTH - WINDOW_HEADER_HEIGHT;
     }
 
     return {


### PR DESCRIPTION
**Changes:**

- The desktop keeps track of window positions for the plugins based on plugin identifier and their instance ID. As per UX input, windows open in the center of the desktop by default, or if their default size is too big, it resizes and moves the window upwards (as Zowe did before). Position data is saved every time a major window handler is executed (create window, maximize, minimize, restore, close). It may be bad to save data every time a window is moved, go to very bottom for more info***.

- If a user opens up a plugin, moves it to a new location, resizes it, and then closes it, when they open it back up, it will pop up right where they left off. By design, this fixes the bug where you could close and re-open the same program any number of times, cascading it farther and farther down the page.

- This is compatible with the **[Feature for multiple instances of applications](https://github.com/zowe/zlux-app-manager/pull/65)** PR by Suneeth. To prepare for multi-instance plugins, these changes are compatible by cascading multiple instances of the same plugin downwards and to the right. Similar to many operating systems, if I opened 3 instances of the Code Editor, I would get:

![image](https://user-images.githubusercontent.com/20528015/50363700-cc93ef80-053a-11e9-86f5-b6c146f89e49.png)

To test this, you can git checkout directly into: 
**[DivergentEuropeans:window-management-multi-instance](https://github.com/DivergentEuropeans/zlux-app-manager/tree/window-management-multi-instance)**
(The logic in this branch is no different than this PR except that it has the multi-instance-app changes.) 



***Additionally, I have made a different branch similar to the one above, except it saves the position data every time a window is moved (basically in real-time instead of the major window handler events). This may be bad, because every time a window is moved, Angular will fire off the move event about half a hundred times per second, sometimes a dozen events per pixel. This can be very draining performance-wise, and I noticed a 15-20% CPU usage on Chrome, which is why I wouldn't recommend doing it this way. The branch that does it is here:
**[DivergentEuropeans:window-management-multi-instance-realtime](https://github.com/DivergentEuropeans/zlux-app-manager/tree/window-management-multi-instance-realtime)**
The drawback to not using this and saving on performance, is accuracy. A situation comes to mind where you open 2 instances, instance 1 and instance 2, of the same plugin. Now move instance 2, and then open a new instance 3 of the same plugin. This new instance 3, will cascade in instance 2's original location, not instance 2's moved location, because remember, the positions get updated based on the major window handler events, not the move events which are too numerous. It's really a small compromise in my opinion, performance is very important, and the situation that I described can probably be fixed in later bug tickets, by checking for when a user is "done" moving the program by having some kind of event listener.



