### PR TITLE
Multi window fixes for UI & behavior

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
@@ -62,7 +62,8 @@ export class LaunchbarInstanceViewComponent {
       return item.windowPreviews[index].src;
     }
     catch(err) {
-      console.log("Unsupported screenshot loaded/iFrame applications currently not supported")
+      // this spams when preview is pending or App doesnt work with preview,
+      // and the failure case is obvious enough that a console log doesnt help
       return null;
     }
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -183,16 +183,17 @@ export class LaunchbarComponent {
     var menuItems: ContextMenuItem[];
     if (item.instanceCount == 1) {
         menuItems = [
-          this.pluginsDataService.pinContext(item),
           { "text": this.translation.translate("Open New"), "action": ()=> this.openWindow(item)},
-          { "text": this.translation.translate("Close All"), "action": ()=> this.closeAllWindows(item)},
+          { "text": this.translation.translate('BringToFront'), "action": () => this.bringItemFront(item) },
+          this.pluginsDataService.pinContext(item),
           { "text": this.translation.translate('Properties'), "action": () => this.launchPluginPropertyWindow(item.plugin) },
-          { "text": this.translation.translate('BringToFront'), "action": () => this.bringItemFront(item) }
+          { "text": this.translation.translate("Close All"), "action": ()=> this.closeAllWindows(item)},
         ];
     } else if (item.instanceCount != 0) {
       menuItems = [
-        this.pluginsDataService.pinContext(item),
         { "text": this.translation.translate("Open New"), "action": ()=> this.openWindow(item)},
+        this.pluginsDataService.pinContext(item),
+        { "text": this.translation.translate('Properties'), "action": () => this.launchPluginPropertyWindow(item.plugin) },
         { "text": this.translation.translate("Close All"), "action": ()=> this.closeAllWindows(item)}
       ];
     } else {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -36,7 +36,14 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
    */
   public static readonly WINDOW_HEADER_HEIGHT = 45;
   public static readonly LAUNCHBAR_HEIGHT = 60;
+  //The icons peek a bit above the launchbar
+  public static readonly LAUNCHBAR_ICON_HEIGHT_FLOAT = 15;
   private static readonly NEW_WINDOW_POSITION_INCREMENT = WindowManagerService.WINDOW_HEADER_HEIGHT;
+  private static readonly MAXIMIZE_WINDOW_HEIGHT_OFFSET = WindowManagerService.WINDOW_HEADER_HEIGHT
+                                                        + WindowManagerService.LAUNCHBAR_HEIGHT
+                                                        + WindowManagerService.LAUNCHBAR_ICON_HEIGHT_FLOAT
+                                                        //Padding for a cleaner UI look
+                                                        + 5;
 
   private nextId: MVDWindowManagement.WindowId;
   private windowMap: Map<MVDWindowManagement.WindowId, DesktopWindow>;
@@ -96,7 +103,12 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
 
  
   private refreshMaximizedWindowSize(desktopWindow: DesktopWindow): void {
-    desktopWindow.windowState.position = { top: 0, left: 0, width: window.innerWidth, height: window.innerHeight };
+    //this is the window viewport size, so you must subtract the header and launchbar from the height.
+    desktopWindow.windowState.position = { top: 0,
+                                           left: 0,
+                                           width: window.innerWidth,
+                                           height: window.innerHeight
+                                           - WindowManagerService.MAXIMIZE_WINDOW_HEIGHT_OFFSET};
   }
 
   private generateWindowId(): MVDWindowManagement.WindowId {
@@ -432,6 +444,10 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     if (desktopWindow == null) {
       console.warn('Attempted to request focus for null window');
       return false;
+    }
+    //can't focus an unseen window!
+    if (desktopWindow.windowState.stateType === DesktopWindowStateType.Minimized) {
+      this.restore(destination);
     }
 
     this.focusedWindow = desktopWindow;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.css
@@ -43,10 +43,6 @@
 }
 
 .window.maximized {
-  top: 0 !important;
-  left: 0 !important;
-  width: calc(100% - 2px) !important;
-  height: calc(100% - 2px)  !important;
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
 }


### PR DESCRIPTION
Fixing: excessive app snapshot viewer logging during generation period, maximized windows getting cut off by launchbar, app instance viewer being unable to bring windows into focus when minimized, and context menu item order for app icons

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>