### PR TITLE
Support angular as an alias for angular2

### DIFF
--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
@@ -103,7 +103,7 @@ export class Angular2PluginFactory extends PluginFactory {
   }
 
   acceptableFrameworks(): string[] {
-    return ['angular2'];
+    return ['angular2', 'angular'];
   }
 
   loadComponentFactories(pluginDefinition: MVDHosting.DesktopPluginDefinition): Promise<void> {


### PR DESCRIPTION
Have angular2-plugin-factory support 'angular' apps, such that we can stop calling things angular2 at a user-facing level

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>