### PR TITLE
Build fix for missing alias

### DIFF
--- a/virtual-desktop/webpack.externals.js
+++ b/virtual-desktop/webpack.externals.js
@@ -19,6 +19,11 @@ var config = {
     "main": "./src/externals-main.ts",
     "externals": "./src/externals.ts"
   },
+  "resolve": {
+    "alias": {
+      "virtual-desktop-logger": path.resolve(__dirname, "src/app/shared/logger.ts"),
+    }
+  },
   "output": {
     "filename": "[name].js",
     "path": path.resolve(__dirname, "web")


### PR DESCRIPTION
Externals building fails to find virtual desktop logger, due to missing alias. This fixes it

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>