### PR TITLE
Using factory to get a private dispatcher

### DIFF
--- a/bootstrap/src/bootstrap/dsm-resources.ts
+++ b/bootstrap/src/bootstrap/dsm-resources.ts
@@ -12,7 +12,7 @@
 
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 import { DsmUri } from '../uri/dsm-uri'
-import { Dispatcher } from 'zlux-base/dispatcher/dispatcher'
+import { DispatcherFactory } from 'zlux-base/dispatcher/dispatcher'
 import { Logger } from '../../../../zlux-shared/src/logging/logger'
 import { Registry } from 'zlux-base/registry/registry'
 import { NotificationManager } from 'zlux-base/notification-manager/notification-manager'
@@ -22,11 +22,12 @@ import { SimpleGlobalization } from '../i18n/simple-globalization'
 declare var window: { ZoweZLUX: typeof DSMResources };
 window; /* Suppress TS error */
 let logger = new Logger();
+
 logger.addDestination(logger.makeDefaultDestination(true,true,true));
 export class DSMResources {
   static pluginManager = PluginManager
   static uriBroker:ZLUX.UriBroker = new DsmUri();
-  static dispatcher:Dispatcher = new Dispatcher(logger);
+  static dispatcher:ZLUX.Dispatcher = new DispatcherFactory().makeDispatcher(logger);
   static logger:Logger = logger;
   static registry:ZLUX.Registry = new Registry();
   static notificationManager:NotificationManager = new NotificationManager();

--- a/bootstrap/src/bootstrap/rocket-mvd-resources.ts
+++ b/bootstrap/src/bootstrap/rocket-mvd-resources.ts
@@ -12,7 +12,7 @@
 
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 import { MvdUri } from '../uri/mvd-uri'
-import { Dispatcher } from 'zlux-base/dispatcher/dispatcher'
+import { DispatcherFactory } from 'zlux-base/dispatcher/dispatcher'
 import { Logger } from '../../../../zlux-shared/src/logging/logger'
 import { Registry } from 'zlux-base/registry/registry'
 import { NotificationManager } from 'zlux-base/notification-manager/notification-manager'
@@ -29,7 +29,7 @@ window.COM_RS_COMMON_LOGGER = logger;
 export class ZoweZLUXResources {
   static pluginManager = PluginManager
   static uriBroker:ZLUX.UriBroker = new MvdUri();
-  static dispatcher:Dispatcher = new Dispatcher(logger);
+  static dispatcher:ZLUX.Dispatcher = new DispatcherFactory().makeDispatcher(logger);
   static logger:Logger = logger;
   static registry:ZLUX.Registry = new Registry();
   static notificationManager:NotificationManager = new NotificationManager();


### PR DESCRIPTION
Changing the dispatcher into a private object seemed to lead to needing a factory in order to fit the global object that existed previously.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>