### PR TITLE
IFrame focus-on-click + Windows get focus via resize handles

### DIFF
--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -125,7 +125,7 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
   private spawnApplicationIntoViewport(plugin: DesktopPluginDefinitionImpl, launchMetadata: any,
     applicationInstance: ApplicationInstance, viewportId: MVDHosting.ViewportId): Promise<MVDHosting.InstanceId> {
     // TODO: race condition?
-    return this.pluginLoader.loadPlugin(plugin)
+    return this.pluginLoader.loadPlugin(plugin, viewportId)
       .then((compiled): MVDHosting.InstanceId => {
         //  When angular module is compiled, it produces and ngModuleFactory
         //  The ngModuleFactory, when given an injector produces a module ref

--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -125,7 +125,7 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
   private spawnApplicationIntoViewport(plugin: DesktopPluginDefinitionImpl, launchMetadata: any,
     applicationInstance: ApplicationInstance, viewportId: MVDHosting.ViewportId): Promise<MVDHosting.InstanceId> {
     // TODO: race condition?
-    return this.pluginLoader.loadPlugin(plugin, viewportId)
+    return this.pluginLoader.loadPlugin(plugin, applicationInstance.instanceId)
       .then((compiled): MVDHosting.InstanceId => {
         //  When angular module is compiled, it produces and ngModuleFactory
         //  The ngModuleFactory, when given an injector produces a module ref

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
@@ -136,7 +136,7 @@ export class Angular2PluginFactory extends PluginFactory {
     });
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, id: MVDHosting.ViewportId): Promise<CompiledPlugin> {
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, instanceId: MVDHosting.InstanceId): Promise<CompiledPlugin> {
     this.loadComponentFactories(pluginDefinition);
     const scriptUrl = Angular2PluginFactory.getAngularModuleURL(pluginDefinition);
 

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
@@ -136,7 +136,7 @@ export class Angular2PluginFactory extends PluginFactory {
     });
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition): Promise<CompiledPlugin> {
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, id: MVDHosting.ViewportId): Promise<CompiledPlugin> {
     this.loadComponentFactories(pluginDefinition);
     const scriptUrl = Angular2PluginFactory.getAngularModuleURL(pluginDefinition);
 

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -34,7 +34,7 @@ export class IFramePluginFactory extends PluginFactory {
     window.addEventListener("blur", (event) => { //Checks if focus is lost from the desktop
       if (iFrameElement != null && document.activeElement.className == "mvd-iframe") //Checks if an IFrame caused it
       {
-        let stringId = iFrameElement.id.replace(/[^0-9\.]+/g, ""); //Extracts the Window ID from the IFrame ID
+        let stringId = iFrameElement.id.replace(/[^0-9\.]+/g, ""); //Extracts the instance ID from the IFrame ID
         const windowManager: MVDWindowManagement.WindowManagerServiceInterface = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
         windowManager.showWindow(parseInt(stringId, 10)); 
       }
@@ -50,7 +50,7 @@ export class IFramePluginFactory extends PluginFactory {
       return ['iframe'];
     }
 
-  private createIFrameComponentClass(pluginDefinition: MVDHosting.DesktopPluginDefinition, pluginId: MVDHosting.ViewportId): Type<any> {
+  private createIFrameComponentClass(pluginDefinition: MVDHosting.DesktopPluginDefinition, instanceId: MVDHosting.InstanceId): Type<any> {
     const basePlugin = pluginDefinition.getBasePlugin();
     const startingPage = basePlugin.getWebContent().startingPage || 'index.html';
     this.logger.debug('iframe startingPage', startingPage);
@@ -63,7 +63,7 @@ export class IFramePluginFactory extends PluginFactory {
     this.logger.debug('iframe startingPageUri', startingPageUri);
     const safeStartingPageUri: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(startingPageUri);
     this.logger.info(`Loading iframe, URI=${startingPageUri}`);
-    const theIframeId = "mvd_iframe_" + (pluginId); //Syncs the IFrame ID with its Window ID counterpart
+    const theIframeId = "mvd_iframe_" + (instanceId); //Syncs the IFrame ID with its instance ID counterpart
     return class IFrameComponentClass {
       startingPage: SafeResourceUrl = safeStartingPageUri;
       iframeId:string = theIframeId;

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -14,6 +14,7 @@ import { Compiler, Component, Injectable, NgModule, Type, Injector } from '@angu
 import { CommonModule } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { PluginFactory } from '../plugin-factory';
+//import { DesktopPluginDefinition } from '../../shared/desktop-plugin-definition';
 import { CompiledPlugin } from '../../shared/compiled-plugin';
 import { BaseLogger } from 'virtual-desktop-logger';
 

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -10,12 +10,10 @@
   Copyright Contributors to the Zowe Project.
 */
 
-import { Compiler, Component, Injectable, NgModule, Type } from '@angular/core';
+import { Compiler, Component, Injectable, NgModule, Type, Injector } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-
 import { PluginFactory } from '../plugin-factory';
-//import { DesktopPluginDefinition } from '../../shared/desktop-plugin-definition';
 import { CompiledPlugin } from '../../shared/compiled-plugin';
 import { BaseLogger } from 'virtual-desktop-logger';
 
@@ -27,10 +25,22 @@ let iFrameElement: HTMLElement;
 export class IFramePluginFactory extends PluginFactory {
   private readonly logger: ZLUX.ComponentLogger = BaseLogger;
   constructor(
+    private injector: Injector,
     private compiler: Compiler,
     private sanitizer: DomSanitizer
   ) {
     super();
+    window.addEventListener("blur", (event) => { //Checks if focus is lost from the desktop
+      if (iFrameElement != null && document.activeElement.className == "mvd-iframe") //Checks if an IFrame caused it
+      {
+        let stringId = iFrameElement.id.replace(/[^0-9\.]+/g, ""); //Extracts the Window ID from the IFrame ID
+        const windowManager: MVDWindowManagement.WindowManagerServiceInterface = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
+        windowManager.showWindow(parseInt(stringId, 10)); 
+      }
+    }, false);
+    window.addEventListener("mouseover", (event) => {
+      window.focus(); //Without giving focus back to the desktop, there is no easy way to tell for clicks between IFrame to IFrame
+    }, false);
   }
 
   static iframeIndex:number = 1;
@@ -39,7 +49,7 @@ export class IFramePluginFactory extends PluginFactory {
       return ['iframe'];
     }
 
-  private createIFrameComponentClass(pluginDefinition: MVDHosting.DesktopPluginDefinition): Type<any> {
+  private createIFrameComponentClass(pluginDefinition: MVDHosting.DesktopPluginDefinition, pluginId: MVDHosting.ViewportId): Type<any> {
     const basePlugin = pluginDefinition.getBasePlugin();
     const startingPage = basePlugin.getWebContent().startingPage || 'index.html';
     this.logger.debug('iframe startingPage', startingPage);
@@ -52,7 +62,7 @@ export class IFramePluginFactory extends PluginFactory {
     this.logger.debug('iframe startingPageUri', startingPageUri);
     const safeStartingPageUri: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(startingPageUri);
     this.logger.info(`Loading iframe, URI=${startingPageUri}`);
-    const theIframeId = "mvd_iframe_"+(IFramePluginFactory.iframeIndex++);
+    const theIframeId = "mvd_iframe_" + (pluginId); //Syncs the IFrame ID with its Window ID counterpart
     return class IFrameComponentClass {
       startingPage: SafeResourceUrl = safeStartingPageUri;
       iframeId:string = theIframeId;
@@ -75,8 +85,8 @@ export class IFramePluginFactory extends PluginFactory {
     return Promise.resolve();
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition): Promise<CompiledPlugin> {
-    const componentClass = this.createIFrameComponentClass(pluginDefinition);
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, pluginId: MVDHosting.ViewportId): Promise<CompiledPlugin> {
+    const componentClass = this.createIFrameComponentClass(pluginDefinition, pluginId);
     const metadata = {
       selector: 'rs-com-mvd-iframe-component',
       templateUrl: './iframe-plugin.component.html',

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -86,8 +86,8 @@ export class IFramePluginFactory extends PluginFactory {
     return Promise.resolve();
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, pluginId: MVDHosting.ViewportId): Promise<CompiledPlugin> {
-    const componentClass = this.createIFrameComponentClass(pluginDefinition, pluginId);
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, instanceId: MVDHosting.InstanceId): Promise<CompiledPlugin> {
+    const componentClass = this.createIFrameComponentClass(pluginDefinition, instanceId);
     const metadata = {
       selector: 'rs-com-mvd-iframe-component',
       templateUrl: './iframe-plugin.component.html',

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/plugin-factory.ts
@@ -15,7 +15,7 @@ import { CompiledPlugin } from '../shared/compiled-plugin';
 
 export abstract class PluginFactory {
   abstract acceptableFrameworks(): string[];
-  abstract loadPlugin(plugin: MVDHosting.DesktopPluginDefinition): Promise<CompiledPlugin>;
+  abstract loadPlugin(plugin: MVDHosting.DesktopPluginDefinition, id: MVDHosting.ViewportId): Promise<CompiledPlugin>;
   abstract loadComponentFactories(plugin: MVDHosting.DesktopPluginDefinition): Promise<void>;
 }
 

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/react/react-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/react/react-plugin-factory.ts
@@ -64,7 +64,7 @@ export class ReactPluginFactory extends PluginFactory {
     });
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, id: MVDHosting.ViewportId): Promise<CompiledPlugin> {
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, instanceId: MVDHosting.InstanceId): Promise<CompiledPlugin> {
     const scriptUrl = ReactPluginFactory.getReactModuleURL(pluginDefinition);
     return new Promise((resolve, reject) => {
       (window as any).require([scriptUrl],

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/react/react-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/react/react-plugin-factory.ts
@@ -64,7 +64,7 @@ export class ReactPluginFactory extends PluginFactory {
     });
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition): Promise<CompiledPlugin> {
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, id: MVDHosting.ViewportId): Promise<CompiledPlugin> {
     const scriptUrl = ReactPluginFactory.getReactModuleURL(pluginDefinition);
     return new Promise((resolve, reject) => {
       (window as any).require([scriptUrl],

--- a/virtual-desktop/src/app/plugin-manager/shared/plugin-loader.ts
+++ b/virtual-desktop/src/app/plugin-manager/shared/plugin-loader.ts
@@ -47,9 +47,8 @@ export class PluginLoader {
     });
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition): Promise<CompiledPlugin> {
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, windowId: MVDHosting.ViewportId): Promise<CompiledPlugin> {
     const candidateFactories = this.frameworkMap.get(pluginDefinition.getFramework()) || [];
-
     if (pluginDefinition.getFramework() === 'unsupported') {
       return new Promise((resolve, reject) => {
         this.logger.warn(`${pluginDefinition.getIdentifier()} does not use supported framework`);
@@ -64,7 +63,7 @@ export class PluginLoader {
     /* Attempt all registered factories for the given framework */
     return candidateFactories.reduce(
       (promise, factory) => promise.catch((errors: any[]) =>
-        factory.loadPlugin(pluginDefinition).catch((error) => Promise.reject(errors.concat([error])))
+        factory.loadPlugin(pluginDefinition, windowId).catch((error) => Promise.reject(errors.concat([error])))
       ),
       Promise.reject([new Error(`All plugin factories for framework type "${pluginDefinition.getFramework()}" failed`)])
     );

--- a/virtual-desktop/src/app/plugin-manager/shared/plugin-loader.ts
+++ b/virtual-desktop/src/app/plugin-manager/shared/plugin-loader.ts
@@ -47,7 +47,7 @@ export class PluginLoader {
     });
   }
 
-  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, windowId: MVDHosting.ViewportId): Promise<CompiledPlugin> {
+  loadPlugin(pluginDefinition: MVDHosting.DesktopPluginDefinition, instanceId: MVDHosting.InstanceId): Promise<CompiledPlugin> {
     const candidateFactories = this.frameworkMap.get(pluginDefinition.getFramework()) || [];
     if (pluginDefinition.getFramework() === 'unsupported') {
       return new Promise((resolve, reject) => {
@@ -63,7 +63,7 @@ export class PluginLoader {
     /* Attempt all registered factories for the given framework */
     return candidateFactories.reduce(
       (promise, factory) => promise.catch((errors: any[]) =>
-        factory.loadPlugin(pluginDefinition, windowId).catch((error) => Promise.reject(errors.concat([error])))
+        factory.loadPlugin(pluginDefinition, instanceId).catch((error) => Promise.reject(errors.concat([error])))
       ),
       Promise.reject([new Error(`All plugin factories for framework type "${pluginDefinition.getFramework()}" failed`)])
     );

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.html
@@ -59,7 +59,7 @@
   </div>
 
   <!-- Window resize grips -->
-  <div class="draggable-grips">
+  <div class="draggable-grips" (mousedown)="requestFocus()">
     <div class="grip-w" #w></div>
     <div class="grip-s" #s></div>
     <div class="grip-e" #e></div>


### PR DESCRIPTION
• This solves the bug where IFrames can't be selected into focused context by clicking inside them, only by clicking on their window header. This is accomplished by syncing the IFrame IDs with their window array counterparts, instead of using an IFrame index that has no real tie-in to the rest of the desktop environment outside IFrames. Then, we can use the window ID of the IFrame obtained from the event an IFrame fires off when clicked on (which is basically no event but we can instead detect when the desktop loses focus aka a blur, and then check if it was an IFrame).

• This also adds focus to windows via their resize handles. In most OS, for ex. Mac, Windows & most variants of Linux, when you click on a resize handle to resize a window, it puts the window up front into focus, in combination with resizing it. If you go to re-size a non-focused window, Zowe will resize it in the background without giving it focus, which is kind of a weird feature. 

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>