### PR TITLE
changes to proxy path logic to allow api ml integration

### DIFF
--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -12,7 +12,8 @@
 
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 
-const uri_prefix = window.location.pathname.split('ZLUX/plugins/')[0];
+const uri_prefix = window.location.pathname.split('ZLUX/plugins/org.zowe.zlux.bootstrap/web/index.html')[0];
+// const proxy_mode = (uri_prefix !== '/') ? true : false; // Tells whether we're behind API layer (true) or not (false)
 
 export class MvdUri implements ZLUX.UriBroker {
   rasUri(uri: string): string {

--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -12,8 +12,8 @@
 
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 
-const proxy_path = 'zowe-zlux';
-const proxy_mode = (window.location.pathname.split('/')[1] == proxy_path) ? true : false;
+const uri_prefix = window.location.pathname.split('ZLUX/plugins/org.zowe.zlux.bootstrap/web/index.html')[0];
+const proxy_mode = (uri_prefix !== '/') ? true : false;
 
 export class MvdUri implements ZLUX.UriBroker {
   rasUri(uri: string): string {
@@ -84,7 +84,7 @@ export class MvdUri implements ZLUX.UriBroker {
   }
 
   serverRootUri(uri: string): string {
-    return proxy_mode ? `/${proxy_path}/${uri}` : `/${uri}`;
+    return proxy_mode ? `${uri_prefix}${uri}` : `/${uri}`;
   }
 
   pluginResourceUri(pluginDefinition: ZLUX.Plugin, relativePath: string): string {

--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -12,7 +12,7 @@
 
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 
-const uri_prefix = window.location.pathname.split('ZLUX/plugins/org.zowe.zlux.bootstrap/web/index.html')[0];
+const uri_prefix = window.location.pathname.split('ZLUX/plugins/')[0];
 // const proxy_mode = (uri_prefix !== '/') ? true : false; // Tells whether we're behind API layer (true) or not (false)
 
 export class MvdUri implements ZLUX.UriBroker {

--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -12,8 +12,7 @@
 
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 
-const uri_prefix = window.location.pathname.split('ZLUX/plugins/org.zowe.zlux.bootstrap/web/index.html')[0];
-const proxy_mode = (uri_prefix !== '/') ? true : false;
+const uri_prefix = window.location.pathname.split('ZLUX/plugins/')[0];
 
 export class MvdUri implements ZLUX.UriBroker {
   rasUri(uri: string): string {
@@ -84,7 +83,7 @@ export class MvdUri implements ZLUX.UriBroker {
   }
 
   serverRootUri(uri: string): string {
-    return proxy_mode ? `${uri_prefix}${uri}` : `/${uri}`;
+    return `${uri_prefix}${uri}`;
   }
 
   pluginResourceUri(pluginDefinition: ZLUX.Plugin, relativePath: string): string {


### PR DESCRIPTION
This will allow the api ml to redirect to zlux and for zlux to recognize that it's located behind the api ml and should structure requests for resources accordingly