### PR TITLE
Bugfixes to compile with i18n

### DIFF
--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -172,7 +172,7 @@ export class LoginComponent implements OnInit {
     }
   }
 
-  protected detectActivity(): void {
+  detectActivity(): void {
     this.logger.debug('User activity detected');
     this.lastActive = Date.now();
     if (this.idleWarnModal) {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.html
@@ -9,10 +9,10 @@
   
   Copyright Contributors to the Zowe Project.
 -->
-<div class="launchbar-icon" (mouseleave)="onMouseLeaveInstanceView($event, item)">
-<zowe-launchbar-instance-view class="instance" *ngIf="launchbarItem.showInstanceView" [launchbarItem]="launchbarItem" (mouseenter)="onMouseEnterInstanceView($event, item)" (mouseleave)="onMouseLeaveInstanceView($event, item)"></zowe-launchbar-instance-view>
+<div class="launchbar-icon" (mouseleave)="onMouseLeaveInstanceView($event)">
+<zowe-launchbar-instance-view class="instance" *ngIf="launchbarItem.showInstanceView" [launchbarItem]="launchbarItem" (mouseenter)="onMouseEnterInstanceView($event)" (mouseleave)="onMouseLeaveInstanceView($event)"></zowe-launchbar-instance-view>
 <p *ngIf="launchbarItem.showIconLabel" class="launchbar-caption truncate">{{launchbarItem.label}}</p>
-<div class="launchbar-icon-image" (mouseenter)="onMouseEnter($event, item)" (mouseleave)="onMouseLeave($event, item)" [title]="launchbarItem.label" [style.background-image]="launchbarItem.image == null ? undefined : launchbarItem.image | cssUrl">
+<div class="launchbar-icon-image" (mouseenter)="onMouseEnter($event)" (mouseleave)="onMouseLeave($event)" [title]="launchbarItem.label" [style.background-image]="launchbarItem.image == null ? undefined : launchbarItem.image | cssUrl">
   <div class="launchbar-icon-marker-dots" *ngIf="launchbarItem.instanceCount <= 5">
     <div class="launchbar-icon-marker-dot" *ngFor="let i of launchbarItem.instanceIdArray"></div>
   </div>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.ts
@@ -39,22 +39,22 @@ export class LaunchbarIconComponent {
   }
 */  
 
-  onMouseEnter(event: MouseEvent, item: LaunchbarItem) {
+  onMouseEnter(event: MouseEvent) {
     if (!this.launchbarItem.showInstanceView) {
       this.launchbarItem.showIconLabel = true;
     }
   }
 
-  onMouseLeave(event: MouseEvent, item: LaunchbarItem) {
+  onMouseLeave(event: MouseEvent) {
     this.launchbarItem.showIconLabel = false;
   }
 
-  onMouseEnterInstanceView(event: MouseEvent, item: LaunchbarItem) {
+  onMouseEnterInstanceView(event: MouseEvent) {
     this.launchbarItem.showIconLabel = false;
     this.launchbarItem.showInstanceView = true;
   }
 
-  onMouseLeaveInstanceView(event: MouseEvent, item: LaunchbarItem) {
+  onMouseLeaveInstanceView(event: MouseEvent) {
     this.launchbarItem.showInstanceView = false;
     this.launchbarItem.showIconLabel = false;
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
@@ -26,7 +26,7 @@ export class LaunchbarInstanceViewComponent {
   @Input() launchbarItem: LaunchbarItem;
 
   constructor(/*@Inject(MVDHosting.Tokens.ApplicationManagerToken) private applicationManager: MVDHosting.ApplicationManagerInterface*/
-  protected windowManager: WindowManagerService) {
+  public windowManager: WindowManagerService) {
   }
 
   ngOnInit(){

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -31,7 +31,7 @@ const ICONS_CHANGED_HEIGHT = 35;
   providers: [PluginsDataService]
 })
 export class LaunchbarComponent {
-  private allItems: LaunchbarItem[];
+  allItems: LaunchbarItem[];
   runItems: LaunchbarItem[];
   isActive: boolean;
   contextMenuRequested: Subject<{xPos: number, yPos: number, items: ContextMenuItem[]}>;

--- a/virtual-desktop/tsconfig.ngx-i18n.json
+++ b/virtual-desktop/tsconfig.ngx-i18n.json
@@ -10,7 +10,10 @@
     "outDir": "./src/assets/i18n",
     "paths": {
       "@angular/core": ["../node_modules/@angular/core"],
-      "zlux-base/*": ["../../../zlux-platform/base/src/*"]
+      "zlux-base/*": ["../../../zlux-platform/base/src/*"],
+      "virtual-desktop-logger": [
+        "./app/shared/logger"
+      ]      
     }
   }
 }


### PR DESCRIPTION
Running `npm run i18n` for virtual desktop would fail with some minor misconfiguration errors that are cleaned up here without impact to the runtime behavior, except that i18n now works again.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>