### PR TITLE
websocket uri change for api-layer

### DIFF
--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -110,7 +110,9 @@ export class MvdUri implements ZLUX.UriBroker {
     const wsProtocol = (protocol === 'https:') ? 'wss:' : 'ws:';
     const uri = `${wsProtocol}//${window.location.host}${this.pluginRootUri(plugin)}`
         + `services/${serviceName}/${version}/${relativePath}`;
-    return proxy_mode ? uri.replace('ui', 'ws') : uri;
+    // This is a workaround for the mediation layer not having a dynamic way to get the websocket uri for zlux
+    // Since we know our uri is /ui/v1/zlux/ behind the api-layer we replace the ui with ws to get /ws/v1/zlux/
+    return proxy_mode ? uri.replace('/ui/', '/ws/') : uri;
   }
 
   /**

--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -13,7 +13,7 @@
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 
 const uri_prefix = window.location.pathname.split('ZLUX/plugins/')[0];
-// const proxy_mode = (uri_prefix !== '/') ? true : false; // Tells whether we're behind API layer (true) or not (false)
+const proxy_mode = (uri_prefix !== '/') ? true : false; // Tells whether we're behind API layer (true) or not (false)
 
 export class MvdUri implements ZLUX.UriBroker {
   rasUri(uri: string): string {
@@ -108,8 +108,9 @@ export class MvdUri implements ZLUX.UriBroker {
     }
     const protocol = window.location.protocol;
     const wsProtocol = (protocol === 'https:') ? 'wss:' : 'ws:';
-    return `${wsProtocol}//${window.location.host}${this.pluginRootUri(plugin)}`
+    const uri = `${wsProtocol}//${window.location.host}${this.pluginRootUri(plugin)}`
         + `services/${serviceName}/${version}/${relativePath}`;
+    return proxy_mode ? uri.replace('ui', 'ws') : uri;
   }
 
   /**


### PR DESCRIPTION
This change is to ensure when websocket URIs are requested from behind the api mediation layer that routes which look like /ui/v1/zlux/ get changed to /ws/v1/zlux/. Currently there is no dynamic/programmatic way of getting the websocket endpoints so this will have to suffice for now.

Signed-off-by: Reet Chowdhary <rchowdhary@rocketsoftware.com>