### PR TITLE
Encode DSN for unusual PDS member names

### DIFF
--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -52,7 +52,7 @@ export class MvdUri implements ZLUX.UriBroker {
     return `${this.serverRootUri(`unixfile/${routeParam}/${absPathParam}${params}`)}`;
   }
   datasetContentsUri(dsn: string): string {
-    return `${this.serverRootUri(`datasetContents/${dsn}`)}`;
+    return `${this.serverRootUri(`datasetContents/${encodeURIComponent(dsn)}`)}`;
   }
   VSAMdatasetContentsUri(dsn: string, closeAfter?: boolean): string {
     let closeAfterParam = closeAfter ? '?closeAfter=' + closeAfter : '';


### PR DESCRIPTION
Could not load PDS members with # in the name, due to browsers interpreting that for routing. It needs to be uri encoded, then decoded on the other side.
Depends on https://github.com/zowe/zlux-app-manager/pull/110
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>