### PR TITLE
Force non-standard text to retain text style

### DIFF
--- a/system-apps/app-prop-viewer/webClient/src/app/app.component.css
+++ b/system-apps/app-prop-viewer/webClient/src/app/app.component.css
@@ -80,7 +80,7 @@
  
  
 .window .caption {
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-weight: 400;
   font-size: 20px;
   cursor: default;

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.css
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.css
@@ -75,19 +75,19 @@
 }
 
 .login-form .userid {
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-size: 19px;
   color: #353535;
 }
 
 .login-form .password {
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-size: 19px;
   text-transform: uppercase;
 }
 
 .login-form label {
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-size: 17px;
   color: #474747;
   margin-bottom: 0;
@@ -124,13 +124,13 @@
 }
 
 .login-label {
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-size: 20px;
   color: #474747;
 }
 
 .login-plugin-version {
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-size: 16px;
   color: #47474785;
 }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.css
@@ -91,7 +91,7 @@
 }
 
 .window .caption {
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-weight: 400;
   font-size: 20px;
   cursor: default;

--- a/virtual-desktop/src/assets/css/desktop.css
+++ b/virtual-desktop/src/assets/css/desktop.css
@@ -38,7 +38,7 @@ html:fullscreen {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-size: 14px;
   line-height: 1.42857143;
   color: #333;
@@ -305,7 +305,7 @@ body {
   color: white;
   background-color: #3c7299;
   width: 100%;
-  font-family: 'Roboto';
+  font-family: 'Roboto', sans-serif;
   font-size: 13px;
   font-weight: 400;
   display: inline-block;


### PR DESCRIPTION
This forces text to use sans-serif style which means text that defaults to other forms of Roboto all use the same form of Roboto.

![image](https://user-images.githubusercontent.com/20528015/59719708-10666980-91eb-11e9-851d-a193b11ab914.png)

becomes

![image](https://user-images.githubusercontent.com/20528015/59719725-1eb48580-91eb-11e9-98a3-db72c74a0f48.png)

And

![image](https://user-images.githubusercontent.com/20528015/59719832-51f71480-91eb-11e9-9057-3f5ab4d9b49e.png)

becomes

![image](https://user-images.githubusercontent.com/20528015/59719759-312ebf00-91eb-11e9-880a-fd88b2984de0.png)

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>