### PR TITLE
Use plugin description name for tooltip instead of duplicate of title

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.html
@@ -12,7 +12,7 @@
 <div class="launchbar-icon" (mouseleave)="onMouseLeaveInstanceView($event)">
 <zowe-launchbar-instance-view class="instance" *ngIf="launchbarItem.showInstanceView" [launchbarItem]="launchbarItem" (mouseenter)="onMouseEnterInstanceView($event)" (mouseleave)="onMouseLeaveInstanceView($event)"></zowe-launchbar-instance-view>
 <p *ngIf="launchbarItem.showIconLabel" class="launchbar-caption truncate">{{launchbarItem.label}}</p>
-<div class="launchbar-icon-image" (mouseenter)="onMouseEnter($event)" (mouseleave)="onMouseLeave($event)" [title]="launchbarItem.label" [style.background-image]="launchbarItem.image == null ? undefined : launchbarItem.image | cssUrl">
+<div class="launchbar-icon-image" (mouseenter)="onMouseEnter($event)" (mouseleave)="onMouseLeave($event)" [title]="launchbarItem.tooltip" [style.background-image]="launchbarItem.image == null ? undefined : launchbarItem.image | cssUrl">
   <div class="launchbar-icon-marker-dots" *ngIf="launchbarItem.instanceCount <= 5">
     <div class="launchbar-icon-marker-dot" *ngFor="let i of launchbarItem.instanceIdArray"></div>
   </div>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
@@ -22,7 +22,7 @@
         <p>Preferences</p>
     </div>
     <hr class="launchbar-separator-hor"> -->
-    <div class="launch-widget-row" *ngFor="let item of menuItems" (click)="clicked(item)" (contextmenu)="onRightClick($event, item)">
+    <div class="launch-widget-row" *ngFor="let item of menuItems" (click)="clicked(item)" [title]="item.tooltip" (contextmenu)="onRightClick($event, item)">
       <img class="icon" [src]="item.image">
       <p>{{item.label}}</p>
     </div>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-item.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-item.ts
@@ -15,6 +15,7 @@ import { DesktopPluginDefinitionImpl } from 'app/plugin-manager/shared/desktop-p
 export abstract class LaunchbarItem {
   abstract readonly label: string;
   abstract readonly image: string | null;
+  abstract readonly tooltip: string;
   abstract readonly plugin: DesktopPluginDefinitionImpl;
   abstract readonly launchMetadata: any;
   abstract readonly instanceCount: number;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
@@ -34,6 +34,10 @@ export class PluginLaunchbarItem extends LaunchbarItem{// implements ZLUX.Plugin
     ZoweZLUX.dispatcher.registerPluginWatcher(plugin.getBasePlugin(), this);
   }
 
+  get tooltip(): string {
+    return this.plugin.basePlugin.getWebContent().descriptionDefault;
+  }
+
   get label(): string {
     return this.plugin.label;
   }


### PR DESCRIPTION
Some apps do not have great descriptions at this time, but the tooltip should provide more info instead of identical info, twice as is the current state.
plugindefinition for apps contains pluginShortName &  description attributes. Today, the name & tooltip is both pluginShortName, but with this PR the tooltip uses description instead.
Implements https://github.com/zowe/zlux/issues/162
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>