### PR TITLE
Fixed multi-window indicator bug

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -66,7 +66,7 @@ export class LaunchbarComponent {
      this.helperLoggedIn = false; //helperLoggedIn is to indicate when the initial login happens
    }
   
-  ngOnInit(): void {
+  getAllItems(): void {
     this.allItems = [];
     this.pluginManager.loadApplicationPluginDefinitions().then(pluginDefinitions => {
       pluginDefinitions.forEach((p)=> {
@@ -94,6 +94,7 @@ export class LaunchbarComponent {
     }
     if (this.loggedIn) {
       if(this.helperLoggedIn != true){
+        this.getAllItems();
         this.pluginsDataService.refreshPinnedPlugins(this.allItems);
         this.helperLoggedIn = true;
       }


### PR DESCRIPTION
The reason the issue was happening only on the unpinned plugins was that the pinned plugins would be refreshed every time there was a new login, all the plugins were only refreshed once the launch bar was initialized. I changed it so all the plugins would be refreshed every time there is a new login which fixes the bug described: https://jira.rocketsoftware.com/browse/MVD-2787