### PR TITLE
Prevent tab from switching Zowe application

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -66,7 +66,7 @@ export class LaunchbarComponent {
      this.helperLoggedIn = false; //helperLoggedIn is to indicate when the initial login happens
    }
   
-  ngOnInit(): void {
+  getAllItems(): void {
     this.allItems = [];
     this.pluginManager.loadApplicationPluginDefinitions().then(pluginDefinitions => {
       pluginDefinitions.forEach((p)=> {
@@ -94,6 +94,7 @@ export class LaunchbarComponent {
     }
     if (this.loggedIn) {
       if(this.helperLoggedIn != true){
+        this.getAllItems();
         this.pluginsDataService.refreshPinnedPlugins(this.allItems);
         this.helperLoggedIn = true;
       }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -102,11 +102,11 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   }
 
   private blockTabOnUnfocusedWindow(): void {
-    document.addEventListener("keyup", (event) => {
+    let blockTab = (event: any) => {
       if(this.focusedWindow != null){
         if(event.which == 9){ // tab
-          let activeElemParents = this.getParentElements(event.target);
-          let parentViewportID:Number = -1;
+          let activeElemParents = this.getParentElements(document.activeElement);
+          let parentViewportID: Number = -1;
           let parentViewport = activeElemParents.find((elem) => {
             return elem.nodeName.toLowerCase() === 'com-rs-mvd-viewport'
           });
@@ -115,12 +115,14 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
             if(Number(this.focusedWindow.viewportId) != parentViewportID){
               this.getHTML(this.focusedWindow.windowId).setAttribute('tabindex', '0');
               this.getHTML(this.focusedWindow.windowId).focus();
-              console.log('Element in background window currently active');
+              this.getHTML(this.focusedWindow.windowId).setAttribute('tabindex', null);
             }
           }
         }
       }
-    });
+    }
+    document.addEventListener('keyup', blockTab, false);
+    document.addEventListener('keydown', blockTab, false);
   }
 
   private getParentElements(element: any){

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -97,6 +97,40 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         .filter(win => win.windowState.stateType === DesktopWindowStateType.Maximized)
         .forEach(win => this.refreshMaximizedWindowSize(win));
     });
+
+    this.blockTabOnUnfocusedWindow();
+  }
+
+  private blockTabOnUnfocusedWindow(): void {
+    document.addEventListener("keyup", (event) => {
+      if(this.focusedWindow != null){
+        if(event.which == 9){ // tab
+          let activeElemParents = this.getParentElements(event.target);
+          let parentViewportID:Number = -1;
+          let parentViewport = activeElemParents.find((elem) => {
+            return elem.nodeName.toLowerCase() === 'com-rs-mvd-viewport'
+          });
+          if(parentViewport !== undefined){
+            parentViewportID = parentViewport.getAttribute('ng-reflect-viewport-id');
+            if(Number(this.focusedWindow.viewportId) != parentViewportID){
+              this.getHTML(this.focusedWindow.windowId).setAttribute('tabindex', '0');
+              this.getHTML(this.focusedWindow.windowId).focus();
+              console.log('Element in background window currently active');
+            }
+          }
+        }
+      }
+    });
+  }
+
+  private getParentElements(element: any){
+    var parents = [];
+    var iElem = element;
+    while(iElem.parentNode !== document && iElem.parentNode.nodeName.toLowerCase() !== 'body'){
+      parents.unshift(iElem.parentNode);
+      iElem = iElem.parentNode;
+    }
+    return parents;
   }
 
   /* TODO: https://github.com/angular/angular/issues/17725 gets in the way */

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -102,23 +102,16 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   }
 
   private blockTabOnUnfocusedWindow(): void {
-    let blockTab = (event: any) => {
+    let blockTab = (event: KeyboardEvent) => {
       if(this.focusedWindow != null){
-        if(event.which == 9){ // tab
-          let activeElemParents = this.getParentElements(document.activeElement);
-          let parentViewportID: Number = -1;
-          let parentViewport = activeElemParents.find((elem) => {
-            return elem.nodeName.toLowerCase() === 'com-rs-mvd-viewport'
-          });
-          if(parentViewport !== undefined){
-            parentViewportID = parentViewport.getAttribute('ng-reflect-viewport-id');
-            if(Number(this.focusedWindow.viewportId) != parentViewportID){
-              let focusHTML = this.getHTML(this.focusedWindow.windowId);
-              let focusTabIndex = focusHTML.getAttribute('tabindex');
-              focusHTML.setAttribute('tabindex', '0');
-              focusHTML.focus();
-              focusHTML.setAttribute('tabindex', focusTabIndex);
-            }
+        if(event.keyCode == 9){ // tab
+          let activeViewportID = this.getViewportIdFromDOM(document.activeElement);
+          if(activeViewportID != Number(this.focusedWindow.viewportId)){
+            let focusHTML = this.getHTML(this.focusedWindow.windowId);
+            let focusTabIndex = focusHTML.getAttribute('tabindex');
+            focusHTML.setAttribute('tabindex', '0');
+            focusHTML.focus();
+            focusHTML.setAttribute('tabindex', focusTabIndex);
           }
         }
       }
@@ -127,14 +120,17 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     document.addEventListener('keydown', blockTab, false);
   }
 
-  private getParentElements(element: any){
-    var parents = [];
-    var iElem = element;
-    while(iElem.parentNode !== document && iElem.parentNode.nodeName.toLowerCase() !== 'body'){
-      parents.unshift(iElem.parentNode);
-      iElem = iElem.parentNode;
+  private getViewportIdFromDOM(element: any){
+    var parentViewportElement: any;
+    var head = element;
+    while(head.parentNode !== document && head.parentNode.nodeName.toLowerCase() !== 'body'){
+      if(head.parentNode.nodeName.toLowerCase() === 'com-rs-mvd-viewport'){
+        parentViewportElement = head.parentNode;
+        break;
+      }
+      head = head.parentNode;
     }
-    return parents;
+    return (parentViewportElement !== undefined) ? parentViewportElement.getAttribute('ng-reflect-viewport-id') : -1;
   }
 
   /* TODO: https://github.com/angular/angular/issues/17725 gets in the way */

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -113,9 +113,11 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
           if(parentViewport !== undefined){
             parentViewportID = parentViewport.getAttribute('ng-reflect-viewport-id');
             if(Number(this.focusedWindow.viewportId) != parentViewportID){
-              this.getHTML(this.focusedWindow.windowId).setAttribute('tabindex', '0');
-              this.getHTML(this.focusedWindow.windowId).focus();
-              this.getHTML(this.focusedWindow.windowId).setAttribute('tabindex', null);
+              let focusHTML = this.getHTML(this.focusedWindow.windowId);
+              let focusTabIndex = focusHTML.getAttribute('tabindex');
+              focusHTML.setAttribute('tabindex', '0');
+              focusHTML.focus();
+              focusHTML.setAttribute('tabindex', focusTabIndex);
             }
           }
         }


### PR DESCRIPTION
"If you have several zowe applications running and you hit tab enough times to reach the end of the first application, on the next tabs it will go into the next zowe application."
This behavior has been mitigated by adding keyup and keydown listeners for "tab" events.  The viewport ID for the window which contains the active element is derived through the parent node tree, and is compared to the viewport ID of the currently focused window.