### PR TITLE
Prevent tab from switching Zowe application

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -97,6 +97,42 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         .filter(win => win.windowState.stateType === DesktopWindowStateType.Maximized)
         .forEach(win => this.refreshMaximizedWindowSize(win));
     });
+    this.blockTabOnUnfocusedWindow();
+  }
+
+  private blockTabOnUnfocusedWindow(): void {
+    let blockTab = (event: KeyboardEvent) => {
+      if(this.focusedWindow != null){
+        if(event.keyCode == 9){ // tab
+          let activeViewportID = this.getViewportIdFromDOM(document.activeElement);
+          if(activeViewportID != Number(this.focusedWindow.viewportId)){
+            let focusHTML = this.getHTML(this.focusedWindow.windowId);
+            let focusTabIndex = focusHTML.getAttribute('tabindex');
+            focusHTML.setAttribute('tabindex', '0');
+            focusHTML.focus();
+            focusHTML.setAttribute('tabindex', focusTabIndex);
+          }
+        }
+      }
+    }
+    document.addEventListener('keyup', blockTab, false);
+    document.addEventListener('keydown', blockTab, false);
+  }
+
+  private getViewportIdFromDOM(element: any): Number{
+    var parentViewportElement: any;
+    var head = element;
+    while(head.parentNode !== document && head.parentNode.nodeName.toLowerCase() !== 'body'){
+      if(head.parentNode.nodeName.toLowerCase() === 'com-rs-mvd-viewport'){
+        parentViewportElement = head.parentNode;
+        break;
+      }
+      head = head.parentNode;
+    }
+    if(parentViewportElement === undefined){
+      return -1;
+    }
+    return parentViewportElement.getAttribute('ng-reflect-viewport-id');
   }
 
   /* TODO: https://github.com/angular/angular/issues/17725 gets in the way */

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -119,8 +119,10 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private getViewportIdFromDOM(element: any): Number{
     var parentViewportElement: any;
     var head = element;
+    const viewportTag: string = 'com-rs-mvd-viewport';
+    const viewportIdAttr: string = 'rs-com-viewport-id';
     while(head.parentNode !== document){
-      if(head.parentNode.nodeName.toLowerCase() === 'com-rs-mvd-viewport'){
+      if(head.parentNode.nodeName.toLowerCase() === viewportTag){
         parentViewportElement = head.parentNode;
         break;
       }
@@ -129,7 +131,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     if(parentViewportElement === undefined){
       return -1;
     }
-    return parentViewportElement.getAttribute('rs-com-viewport-id');
+    return parentViewportElement.getAttribute(viewportIdAttr);
   }
 
   /* TODO: https://github.com/angular/angular/issues/17725 gets in the way */
@@ -377,7 +379,6 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
           this.maximize(windowId);
         }
       }
-      this.requestWindowFocus(windowId);
     }
   }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -97,13 +97,10 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         .filter(win => win.windowState.stateType === DesktopWindowStateType.Maximized)
         .forEach(win => this.refreshMaximizedWindowSize(win));
     });
-    this.blockTabOnUnfocusedWindow();
-  }
 
-  private blockTabOnUnfocusedWindow(): void {
-    let blockTab = (event: KeyboardEvent) => {
+    let tabHandler = (event: KeyboardEvent) => {
       if(this.focusedWindow != null){
-        if(event.keyCode == 9){ // tab
+        if(event.keyCode == 9 || event.which == 9){ // tab
           let activeViewportID = this.getViewportIdFromDOM(document.activeElement);
           if(activeViewportID != Number(this.focusedWindow.viewportId)){
             let focusHTML = this.getHTML(this.focusedWindow.windowId);
@@ -115,8 +112,8 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         }
       }
     }
-    document.addEventListener('keyup', blockTab, false);
-    document.addEventListener('keydown', blockTab, false);
+    document.addEventListener('keyup', tabHandler, false);
+    document.addEventListener('keydown', tabHandler, false);
   }
 
   private getViewportIdFromDOM(element: any): Number{

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -122,8 +122,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private getViewportIdFromDOM(element: any): Number{
     var parentViewportElement: any;
     var head = element;
-    while(head.parentNode !== document
-          && head.parentNode.nodeName.toLowerCase() !== 'body'){
+    while(head.parentNode !== document){
       if(head.parentNode.nodeName.toLowerCase() === 'com-rs-mvd-viewport'){
         parentViewportElement = head.parentNode;
         break;
@@ -133,7 +132,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     if(parentViewportElement === undefined){
       return -1;
     }
-    return parentViewportElement.getAttribute('ng-reflect-viewport-id');
+    return parentViewportElement.getAttribute('rs-com-viewport-id');
   }
 
   /* TODO: https://github.com/angular/angular/issues/17725 gets in the way */

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -122,7 +122,8 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private getViewportIdFromDOM(element: any): Number{
     var parentViewportElement: any;
     var head = element;
-    while(head.parentNode !== document && head.parentNode.nodeName.toLowerCase() !== 'body'){
+    while(head.parentNode !== document
+          && head.parentNode.nodeName.toLowerCase() !== 'body'){
       if(head.parentNode.nodeName.toLowerCase() === 'com-rs-mvd-viewport'){
         parentViewportElement = head.parentNode;
         break;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.html
@@ -50,7 +50,7 @@
 
   <!-- Window body -->
   <div class="body" (mousedown)="requestFocus()" #windowBody>
-    <com-rs-mvd-viewport [viewportId]="desktopWindow.viewportId">
+    <com-rs-mvd-viewport [viewportId]="desktopWindow.viewportId" [attr.rs-com-viewport-id]="desktopWindow.viewportId">
       <!-- Loading display -->
       <div class="full-center">
         <i class="fa fa-spinner fa-spin fa-3x"></i>


### PR DESCRIPTION
"If you have several zowe applications running and you hit tab enough times to reach the end of the first application, on the next tabs it will go into the next zowe application."
This behavior has been mitigated by adding keyup and keydown listeners for "tab" events. The viewport ID for the window which contains the active element is derived through the parent node tree, and is compared to the viewport ID of the currently focused window.