### PR TITLE
Some snapshot optimization

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-icon/launchbar-icon.component.html
@@ -13,10 +13,10 @@
 <zowe-launchbar-instance-view class="instance" *ngIf="launchbarItem.showInstanceView" [launchbarItem]="launchbarItem" (mouseenter)="onMouseEnterInstanceView($event)" (mouseleave)="onMouseLeaveInstanceView($event)"></zowe-launchbar-instance-view>
 <p *ngIf="launchbarItem.showIconLabel" class="launchbar-caption truncate">{{launchbarItem.label}}</p>
 <div class="launchbar-icon-image" (mouseenter)="onMouseEnter($event)" (mouseleave)="onMouseLeave($event)" [title]="launchbarItem.label" [style.background-image]="launchbarItem.image == null ? undefined : launchbarItem.image | cssUrl">
-  <div class="launchbar-icon-marker-dots" *ngIf="launchbarItem.instanceCount <= 5">
+  <div class="launchbar-icon-marker-dots" *ngIf="launchbarItem.instanceIds.length <= 5">
     <div class="launchbar-icon-marker-dot" *ngFor="let i of launchbarItem.instanceIdArray"></div>
   </div>
-  <div class="launchbar-icon-marker-dots" *ngIf="launchbarItem.instanceCount > 5">
+  <div class="launchbar-icon-marker-dots" *ngIf="launchbarItem.instanceIds.length > 5">
     <div class="launchbar-icon-marker-dot"></div> <!-- 5 dots, plus a + symbol -->
     <div class="launchbar-icon-marker-dot"></div>
     <div class="launchbar-icon-marker-dot"></div>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
@@ -36,11 +36,11 @@ export class LaunchbarInstanceViewComponent {
     let bounds = (<HTMLImageElement>document.getElementsByClassName("instance-viewer")[0]).getBoundingClientRect();
     (<HTMLImageElement>document.getElementsByClassName("instance-viewer")[0]).style.top = (document.body.clientHeight - INSTANCE_TOP_HEIGHT) + 'px';
     if (bounds != null) {
-      if (bounds.left - (INSTANCE_INITIAL_OFFSET + (INSTANCE_ADDITIONAL_OFFSET  * (this.launchbarItem.windowPreviewsIds.length - 2)))  < 0 ) {
+      if (bounds.left - (INSTANCE_INITIAL_OFFSET + (INSTANCE_ADDITIONAL_OFFSET  * (this.launchbarItem.instanceIds.length - 2)))  < 0 ) {
         (<HTMLImageElement>document.getElementsByClassName("instance-viewer")[0]).style.left = 0 + 'px';
       } else {
         (<HTMLImageElement>document.getElementsByClassName("instance-viewer")[0]).style.left = 
-        bounds.left - (INSTANCE_INITIAL_OFFSET + (INSTANCE_ADDITIONAL_OFFSET  * (this.launchbarItem.windowPreviewsIds.length - 2))) + 'px';
+        bounds.left - (INSTANCE_INITIAL_OFFSET + (INSTANCE_ADDITIONAL_OFFSET  * (this.launchbarItem.instanceIds.length - 2))) + 'px';
       }
     }
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -126,10 +126,10 @@ export class LaunchbarComponent {
   }
 
   launchbarItemClicked(event: MouseEvent, item: LaunchbarItem): void {
-    if (item.instanceCount > 1) {
+    if (item.instanceIds.length > 1) {
       item.showInstanceView = !item.showInstanceView;
       (<HTMLImageElement>event.target)!.parentElement!.parentElement!.style.zIndex = '0';
-    } else if (item.instanceCount == 1) {
+    } else if (item.instanceIds.length == 1) {
       let windowId = this.windowManager.getWindow(item.plugin);
       if (windowId != null) {
         if (this.windowManager.windowHasFocus(windowId)){
@@ -185,7 +185,7 @@ export class LaunchbarComponent {
   
   onRightClick(event: MouseEvent, item: LaunchbarItem): boolean {
     var menuItems: ContextMenuItem[];
-    if (item.instanceCount == 1) {
+    if (item.instanceIds.length == 1) {
         menuItems = [
           { "text": this.translation.translate("Open New"), "action": ()=> this.openWindow(item)},
           { "text": this.translation.translate('BringToFront'), "action": () => this.bringItemFront(item) },
@@ -193,7 +193,7 @@ export class LaunchbarComponent {
           { "text": this.translation.translate('Properties'), "action": () => this.launchPluginPropertyWindow(item.plugin) },
           { "text": this.translation.translate("Close All"), "action": ()=> this.closeAllWindows(item)},
         ];
-    } else if (item.instanceCount != 0) {
+    } else if (item.instanceIds.length != 0) {
       menuItems = [
         { "text": this.translation.translate("Open New"), "action": ()=> this.openWindow(item)},
         this.pluginsDataService.pinContext(item),

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-item.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-item.ts
@@ -17,9 +17,8 @@ export abstract class LaunchbarItem {
   abstract readonly image: string | null;
   abstract readonly plugin: DesktopPluginDefinitionImpl;
   abstract readonly launchMetadata: any;
-  abstract readonly instanceCount: number;
   abstract readonly windowPreviews: Array<HTMLImageElement>;
-  abstract readonly windowPreviewsIds: Array<number>;
+  abstract readonly instanceIds: Array<number>;
   showInstanceView: boolean;
   showIconLabel: boolean;
 }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
@@ -17,9 +17,7 @@ import * as html2canvas from 'html2canvas';
 
 export class PluginLaunchbarItem extends LaunchbarItem{// implements ZLUX.PluginWatcher {
   public instanceIds: Array<MVDHosting.InstanceId>;
-  public instanceCount: number;
   public windowPreviews: Array<HTMLImageElement>;
-  public windowPreviewsIds: Array<number>;
 
   constructor(
     public readonly plugin: DesktopPluginDefinitionImpl,
@@ -29,16 +27,18 @@ export class PluginLaunchbarItem extends LaunchbarItem{// implements ZLUX.Plugin
 
     this.instanceIds = [];
     this.windowPreviews = [];
-    this.windowPreviewsIds = [];
-    this.instanceCount = 0;
-    ZoweZLUX.dispatcher.registerPluginWatcher(plugin.getBasePlugin(), this);
-    this.windowManager.screenshotRequestEmitter.subscribe((id)=> {
+    let pluginId = this.plugin.getBasePlugin().getIdentifier();
+    ZoweZLUX.dispatcher.registerPluginWatcher(this.plugin.getBasePlugin(), this);
+    this.windowManager.screenshotRequestEmitter.subscribe((window: {pluginId: string, windowId: number})=> {
+      if (window.pluginId != pluginId) {
+        return;
+      }
       if (this.instanceIds.length < 2) {
         return; //performance hack until we get some task viewer that needs this
       }
-      let index = this.instanceIds.indexOf(id);
+      let index = this.instanceIds.indexOf(window.windowId);
       if (index != -1) {
-        this.generateSnapshot(id);
+        this.generateSnapshot(index);
       }
     });
   }
@@ -59,66 +59,55 @@ export class PluginLaunchbarItem extends LaunchbarItem{// implements ZLUX.Plugin
     return this.instanceIds;
   }
 
-  generateSnapshot(instanceId: MVDHosting.InstanceId){
-    let index = this.instanceIds.indexOf(instanceId);
+  generateSnapshot(index: number){
     var self = this;
-    if(index != -1){
-      var windowIds = this.windowManager.getWindowIDs(this.plugin);
+    let instanceId = self.instanceIds[index];
+    if (instanceId != -1) {
+      var windowHTML = this.windowManager.getHTML(instanceId);
       var imgPrev = new Image();
-      if (windowIds != null) {
-        var windowHTML = this.windowManager.getHTML(windowIds[index]);
-      }
-      let instanceIndex = self.windowPreviewsIds.indexOf(instanceId);
 
-      if (windowIds != null && windowHTML != -1) {
+      if (windowHTML) {
         html2canvas(windowHTML, {logging:false}).then(function(canvas) {
           imgPrev.src = canvas.toDataURL();
-          if (instanceIndex != -1){
-            self.windowPreviews[instanceIndex] = imgPrev;
+          if (self.instanceIds.length == self.windowPreviews.length){
+            self.windowPreviews[index] = imgPrev;
           } else {
             self.windowPreviews.push(imgPrev);
-            self.windowPreviewsIds.push(instanceId);
           }
         });
-      } else if (instanceIndex == -1) {
+      } else if (self.instanceIds.length == self.windowPreviews.length){
         self.windowPreviews.push(imgPrev);
-        self.windowPreviewsIds.push(instanceId);
       }
     }
   }
 
-  destroySnapshot(instanceId: MVDHosting.InstanceId) {
-    let index = this.windowPreviewsIds.indexOf(instanceId);
+  destroySnapshot(index: number) {
     if (index > -1) {
       this.windowPreviews.splice(index, 1);
-      this.windowPreviewsIds.splice(index, 1);
     }
   }
 
   instanceAdded(instanceId: MVDHosting.InstanceId, isEmbedded: boolean|undefined) {
     var self = this;
-    if (this.instanceIds.length != 0) {
-      //skip first for performance
-      setTimeout(function() {
-        self.generateSnapshot(instanceId);
-      }, 3000);
-    } if (this.instanceIds.length == 1) {
-      //go back and init first. slightly worse for performance
-      self.generateSnapshot(this.instanceIds[0]);
-    }
     if (!isEmbedded) {
       this.instanceIds.push(instanceId);
-      this.instanceCount++;
+      let index = this.instanceIds.length-1;
+      if (this.instanceIds.length != 1) {
+        //skip first for performance
+        setTimeout(function() {
+          self.generateSnapshot(index);
+        }, 3000);
+      } if (this.instanceIds.length == 2) {
+        //go back and init first. slightly worse for performance
+        self.generateSnapshot(0);
+      }
     }
   }
   instanceRemoved(instanceId: MVDHosting.InstanceId) {
-    this.destroySnapshot(instanceId);
-    for (let i = 0 ; i < this.instanceIds.length; i++) {
-      if (this.instanceIds[i] === instanceId) {
-        this.instanceIds.splice(i,1);
-        this.instanceCount--;
-        return;
-      }
+    let index = this.instanceIds.indexOf(instanceId);
+    if (index != -1) {
+      this.destroySnapshot(index);
+      this.instanceIds.splice(index,1);
     }
   }
 }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -453,16 +453,16 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   }
 
   requestWindowFocus(destination: MVDWindowManagement.WindowId): boolean {
-    if (!this.windowHasFocus(destination) && this._lastScreenshotId != destination){
-      this.screenshotRequestEmitter.next(this._lastScreenshotId);
-      this._lastScreenshotId = destination;
-    }
-
     const desktopWindow = this.windowMap.get(destination);
     if (desktopWindow == null) {
       this.logger.warn('Attempted to request focus for null window, ID=${destination}');
       return false;
     }
+    let requestScreenshot = false;
+    if (!this.windowHasFocus(destination) && this._lastScreenshotId != destination){
+      requestScreenshot = true;
+    }
+
     //can't focus an unseen window!
     if (desktopWindow.windowState.stateType === DesktopWindowStateType.Minimized) {
       this.restore(destination);
@@ -470,7 +470,12 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
 
     this.focusedWindow = desktopWindow;
     desktopWindow.windowState.zIndex = this.topZIndex ++;
-
+    if (requestScreenshot){
+      setTimeout(()=> {
+        this.screenshotRequestEmitter.next(this._lastScreenshotId);
+        this._lastScreenshotId = destination;
+      },500); //delay a bit for performance perception
+    }
     return true;
   }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -70,7 +70,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private applicationManager: MVDHosting.ApplicationManagerInterface;
   private viewportManager: MVDHosting.ViewportManagerInterface;
   private pluginManager: MVDHosting.PluginManagerInterface;
-  public screenshotRequestEmitter: Subject<MVDWindowManagement.WindowId>;
+  public screenshotRequestEmitter: Subject<{pluginId: string, windowId: MVDWindowManagement.WindowId}>;
 
   constructor(
     private injector: Injector,
@@ -472,7 +472,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     desktopWindow.windowState.zIndex = this.topZIndex ++;
     if (requestScreenshot){
       setTimeout(()=> {
-        this.screenshotRequestEmitter.next(this._lastScreenshotId);
+        this.screenshotRequestEmitter.next({pluginId: desktopWindow.plugin.getIdentifier(), windowId: this._lastScreenshotId});
         this._lastScreenshotId = destination;
       },500); //delay a bit for performance perception
     }
@@ -623,7 +623,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         break;
     }
   }
-
+  
   spawnContextMenu(windowId: MVDWindowManagement.WindowId, xRelative: number, yRelative: number, items: ContextMenuItem[]): void {
     const desktopWindow = this.windowMap.get(windowId);
     if (desktopWindow == null) {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -54,7 +54,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
 
   private focusedWindow: DesktopWindow | null;
   private topZIndex: number;
-  public screenshot: boolean;
+  private _lastScreenshotId: number = -1;
   public showPersonalizationPanel: boolean = false;
   /*
    * NOTES:
@@ -70,6 +70,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private applicationManager: MVDHosting.ApplicationManagerInterface;
   private viewportManager: MVDHosting.ViewportManagerInterface;
   private pluginManager: MVDHosting.PluginManagerInterface;
+  public screenshotRequestEmitter: Subject<MVDWindowManagement.WindowId>;
 
   constructor(
     private injector: Injector,
@@ -90,7 +91,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     this.lastWindowPositionMap = new Map();
     this.contextMenuRequested = new Subject();
     this.windowDeregisterEmitter = new Subject();
-    this.screenshot = true;
+    this.screenshotRequestEmitter = new Subject();
 
     this.windowMonitor.windowResized.subscribe(() => {
       Array.from(this.windowMap.values())
@@ -452,8 +453,9 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   }
 
   requestWindowFocus(destination: MVDWindowManagement.WindowId): boolean {
-    if (!this.windowHasFocus(destination) && this.screenshot == true){
-      this.screenshot = false;
+    if (!this.windowHasFocus(destination) && this._lastScreenshotId != destination){
+      this.screenshotRequestEmitter.next(this._lastScreenshotId);
+      this._lastScreenshotId = destination;
     }
 
     const desktopWindow = this.windowMap.get(destination);

--- a/virtual-desktop/src/pluginlib/inject-resources.ts
+++ b/virtual-desktop/src/pluginlib/inject-resources.ts
@@ -45,7 +45,7 @@ export interface Angular2PluginWindowActions {
   readonly restore: () => void;
   readonly setTitle: (title: string) => void;
   readonly setPosition: (pos: {top: number, left: number, width: number, height: number}) => void;
-  readonly spawnContextMenu: (xPos: number, yPos: number, items: ContextMenuItem[]) => void;
+  readonly spawnContextMenu: (xPos: number, yPos: number, items: ContextMenuItem[], isAbsolutePos?: boolean) => void;
   readonly registerCloseHandler: (handler: () => Promise<void>) => void;
 }
 


### PR DESCRIPTION
Reorganized snapshot logic to not poll, and not snapshot when only 1 instance open per window, since the snapshots cannot be visible at this point.
Also changed to take a snapshot when the window goes out of focus, instead of when it goes into focus, as this gives a better picture of where it was at when you last looked at it.
The difference is visible in idle performance:

![image](https://user-images.githubusercontent.com/30730276/62154131-21b79100-b2d4-11e9-985f-c82023dfc178.png)


Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>