### PR TITLE
Removed window header offset at the top

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.css
@@ -98,6 +98,8 @@
   position: absolute;
   padding-left:83px;
   padding-right:83px;
+  padding-top: 10px;
+  top: 0px;
   left: 0px;
   right: 0px;
   height: 100%;


### PR DESCRIPTION
Removes the offset in the window header towards the top (bug visible where you cannot drag window if you drag from the tippy top)

![image](https://user-images.githubusercontent.com/20528015/62483550-eca0b800-b785-11e9-81c6-e39ea3124ffe.png)
