### PR TITLE
Launchbar fixes (+properties app fixes)

### DIFF
--- a/system-apps/app-prop-viewer/webClient/src/app/app.component.html
+++ b/system-apps/app-prop-viewer/webClient/src/app/app.component.html
@@ -27,6 +27,9 @@
         <span class="constant">App Version</span>: {{appVersion}}
       </p> 
       <p class="app-value">
+        <span class="constant">App ID</span>: {{appId}}
+      </p> 
+      <p class="app-value">
         <span class="constant">App Type</span>: {{appType}}
       </p>
        </div> 

--- a/system-apps/app-prop-viewer/webClient/src/app/app.component.ts
+++ b/system-apps/app-prop-viewer/webClient/src/app/app.component.ts
@@ -23,6 +23,7 @@ export class AppComponent {
   appName:string;
   appVersion:string;
   appType:string;
+  appId: string;
   copyright:string;
   installedApps:string[];
   iconImage:string;
@@ -35,19 +36,44 @@ export class AppComponent {
     this.isPropertyWindow = false;
     this.isViewerWindow = true;
           
-    if (this.launchMetadata != null && this.launchMetadata.isPropertyWindow) {
-      this.appName = this.launchMetadata.appName;
-      this.appVersion = this.launchMetadata.appVersion;
-      this.appType = this.launchMetadata.appType;
-      this.iconImage = this.launchMetadata.image;
-      this.isPropertyWindow = true;
-      this.isViewerWindow = false;
-      this.copyright=this.launchMetadata.copyright;
-    } else if (this.launchMetadata != null && this.launchMetadata.isViewerWindow){
+    if (this.launchMetadata != null && this.launchMetadata.data && this.launchMetadata.data.isPropertyWindow) {
+      this.setInfoFromMessage(this.launchMetadata.data);
+    } else if (this.launchMetadata != null && this.launchMetadata.data && this.launchMetadata.data.isViewerWindow){
       this.isViewerWindow=true;
     }
     
   }
+
+  private setInfoFromMessage(message: any) {
+    this.appName = message.appName;
+    this.appVersion = message.appVersion;
+    this.appId = message.appId;
+    this.appType = message.appType;
+    this.iconImage = message.image;
+    this.isPropertyWindow = true;
+    this.isViewerWindow = false;
+    this.copyright=message.copyright;
+  }
+
+  zluxOnMessage(eventContext: any): Promise<any> {
+    return new Promise((resolve,reject)=> {
+      if (eventContext != null && eventContext.data && eventContext.data.isPropertyWindow) {
+        resolve(this.setInfoFromMessage(eventContext.data));
+      } else {
+        reject('Event context missing or malformed');
+      }
+    });    
+  }
+
+
+  provideZLUXDispatcherCallbacks(): ZLUX.ApplicationCallbacks {
+    return {
+      onMessage: (eventContext: any): Promise<any> => {
+        return this.zluxOnMessage(eventContext);
+      }      
+    }
+  }
+  
 }
 
 /*

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
@@ -19,6 +19,7 @@ import { WindowManagerService } from '../../shared/window-manager.service';
 import { DesktopComponent } from "../../desktop/desktop.component";
 import { TranslationService } from 'angular-l10n';
 import { DesktopPluginDefinitionImpl } from "app/plugin-manager/shared/desktop-plugin-definition";
+import { generateInstanceActions } from '../shared/context-utils';
 
 @Component({
   selector: 'rs-com-launchbar-menu',
@@ -113,11 +114,7 @@ export class LaunchbarMenuComponent {
   }
 
   onRightClick(event: MouseEvent, item: LaunchbarItem): boolean {
-    var menuItems: ContextMenuItem[] =
-      [
-        this.pluginsDataService.pinContext(item),
-        { "text": this.translation.translate('Properties'), "action": () => this.launchPluginPropertyWindow(item.plugin)},
-      ];
+    let menuItems: ContextMenuItem[] = generateInstanceActions(item, this.pluginsDataService, this.translation, this.applicationManager, this.windowManager);    
     this.windowManager.contextMenuRequested.next({ xPos: event.clientX, yPos: event.clientY - 20, items: menuItems });
     return false;
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -19,6 +19,7 @@ import { ContextMenuItem } from 'pluginlib/inject-resources';
 import { WindowManagerService } from '../../shared/window-manager.service';
 import { PluginsDataService } from '../../services/plugins-data.service';
 import { TranslationService } from 'angular-l10n';
+import { generateInstanceActions } from '../shared/context-utils';
 
 const CONTAINER_HEIGHT = 60;
 const ICONS_INITIAL_HEIGHT = -15;
@@ -144,79 +145,14 @@ export class LaunchbarComponent {
     }
   }
 
-  openWindow(item: LaunchbarItem): void {
-    item.showInstanceView = false;
-    this.applicationManager.spawnApplication(item.plugin, null)
-  }
-
   onStateChanged(isActive: boolean): void {
     this.isActive = isActive;
   }
-
-  closeAllWindows(item: LaunchbarItem): void {
-    let windowIds = this.windowManager.getWindowIDs(item.plugin);
-    if (windowIds != null) {
-      windowIds.forEach(windowId => {
-        this.windowManager.closeWindow(windowId);
-      });
-    }
-  }
-
-  getAppPropertyInformation(plugin: DesktopPluginDefinitionImpl):any{
-    const pluginImpl:DesktopPluginDefinitionImpl = plugin as DesktopPluginDefinitionImpl;
-    const basePlugin = pluginImpl.getBasePlugin();
-    return {"isPropertyWindow":true,
-    "appName":pluginImpl.defaultWindowTitle,
-    "appVersion":basePlugin.getVersion(),
-    "appType":basePlugin.getType(),
-    "copyright":pluginImpl.getCopyright(),
-    "image":plugin.image
-    };    
-  }
-  
-  launchPluginPropertyWindow(plugin: DesktopPluginDefinitionImpl){
-    let propertyWindowID = this.windowManager.getWindow(this.propertyWindowPluginDef);
-    if (propertyWindowID!=null){
-      this.windowManager.showWindow(propertyWindowID);
-    } else {
-      this.applicationManager.spawnApplication(this.propertyWindowPluginDef,this.getAppPropertyInformation(plugin));
-    }  
-  }
   
   onRightClick(event: MouseEvent, item: LaunchbarItem): boolean {
-    var menuItems: ContextMenuItem[];
-    if (item.instanceIds.length == 1) {
-        menuItems = [
-          { "text": this.translation.translate("Open New"), "action": ()=> this.openWindow(item)},
-          { "text": this.translation.translate('BringToFront'), "action": () => this.bringItemFront(item) },
-          this.pluginsDataService.pinContext(item),
-          { "text": this.translation.translate('Properties'), "action": () => this.launchPluginPropertyWindow(item.plugin) },
-          { "text": this.translation.translate("Close All"), "action": ()=> this.closeAllWindows(item)},
-        ];
-    } else if (item.instanceIds.length != 0) {
-      menuItems = [
-        { "text": this.translation.translate("Open New"), "action": ()=> this.openWindow(item)},
-        this.pluginsDataService.pinContext(item),
-        { "text": this.translation.translate('Properties'), "action": () => this.launchPluginPropertyWindow(item.plugin) },
-        { "text": this.translation.translate("Close All"), "action": ()=> this.closeAllWindows(item)}
-      ];
-    } else {
-      menuItems =
-        [
-          { "text": this.translation.translate('Open'), "action": () => this.openWindow(item) },
-          this.pluginsDataService.pinContext(item),
-          { "text": this.translation.translate('Properties'), "action": () => this.launchPluginPropertyWindow(item.plugin) },
-        ]
-    }
+    let menuItems: ContextMenuItem[] = generateInstanceActions(item, this.pluginsDataService, this.translation, this.applicationManager, this.windowManager);
     this.windowManager.contextMenuRequested.next({xPos: event.clientX, yPos: event.clientY - 60, items: menuItems});
     return false;
-  }
-
-  bringItemFront(item: LaunchbarItem): void {
-    let windowId = this.windowManager.getWindow(item.plugin);
-    if (windowId != null) {
-      this.windowManager.requestWindowFocus(windowId);
-    }
   }
 
   onMouseDown(event: MouseEvent, item: LaunchbarItem): void {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -123,7 +123,7 @@ export class LaunchbarComponent {
     return openItems;
   }
   menuItemClicked(item: LaunchbarItem): void {
-    this.applicationManager.showApplicationWindow(item.plugin);
+    this.applicationManager.spawnApplication(item.plugin, null)
   }
 
   launchbarItemClicked(event: MouseEvent, item: LaunchbarItem): void {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
@@ -1,0 +1,101 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+import { LaunchbarItem } from './launchbar-item';
+import { DesktopPluginDefinitionImpl } from 'app/plugin-manager/shared/desktop-plugin-definition';
+import { WindowManagerService } from '../../shared/window-manager.service';
+import { PluginsDataService } from '../../services/plugins-data.service';
+import { ContextMenuItem } from 'pluginlib/inject-resources';
+import { TranslationService } from 'angular-l10n';
+
+const PROPERTIES_APP = 'org.zowe.zlux.appmanager.app.propview';
+const PROPERTIES_ARGUMENT_FORMATTER = {data: {op:'deref',source:'event',path:['data']}};
+const UPDATE_PROPERTIES_ACTION = ZoweZLUX.dispatcher.makeAction(PROPERTIES_APP+'.update',
+                                                                'Update Properties View',
+                                                                ZoweZLUX.dispatcher.constants.ActionTargetMode.PluginFindAnyOrCreate,
+                                                                ZoweZLUX.dispatcher.constants.ActionType.Message,
+                                                                PROPERTIES_APP,
+                                                                PROPERTIES_ARGUMENT_FORMATTER);
+
+function closeAllWindows(item: LaunchbarItem, windowManager: WindowManagerService): void {
+  let windowIds = windowManager.getWindowIDs(item.plugin);
+  if (windowIds != null) {
+    windowIds.forEach(windowId => {
+      windowManager.closeWindow(windowId);
+    });
+  }
+}
+
+function bringItemFront(item: LaunchbarItem, windowManager: WindowManagerService): void {
+  let windowId = windowManager.getWindow(item.plugin);
+  if (windowId != null) {
+    windowManager.requestWindowFocus(windowId);
+  }
+}
+
+function getAppPropertyInformation(plugin: DesktopPluginDefinitionImpl):any{
+  const pluginImpl:DesktopPluginDefinitionImpl = plugin as DesktopPluginDefinitionImpl;
+  const basePlugin = pluginImpl.getBasePlugin();
+  return {data:{"isPropertyWindow":true,
+          "appName":pluginImpl.defaultWindowTitle,
+          "appId":pluginImpl.getIdentifier(),
+          "appVersion":basePlugin.getVersion(),
+          "appType":basePlugin.getType(),
+          "copyright":pluginImpl.getCopyright(),
+          "image":plugin.image
+         }};    
+}
+
+
+function launchPluginPropertyWindow(plugin: DesktopPluginDefinitionImpl, windowManager: WindowManagerService){
+  let propertyPluginDef = ZoweZLUX.pluginManager.getPlugin(PROPERTIES_APP);
+  let propertyWindowID = windowManager.getWindow(propertyPluginDef);
+  if (propertyWindowID!=null){
+    windowManager.requestWindowFocus(propertyWindowID);
+  }
+  const info = getAppPropertyInformation(plugin);
+  ZoweZLUX.dispatcher.invokeAction(UPDATE_PROPERTIES_ACTION, info);
+}
+
+function openWindow(item: LaunchbarItem, applicationManager: MVDHosting.ApplicationManagerInterface): void {
+  item.showInstanceView = false;
+  applicationManager.spawnApplication(item.plugin, null)
+}
+
+export function generateInstanceActions(item: LaunchbarItem,
+                                        pluginsDataService: PluginsDataService,
+                                        translationService: TranslationService,
+                                        applicationManager: MVDHosting.ApplicationManagerInterface,
+                                        windowManager: WindowManagerService): ContextMenuItem[] {
+  let menuItems: ContextMenuItem[];
+  if (item.instanceIds.length == 1) {
+    menuItems = [
+      { "text": translationService.translate("Open New"), "action": ()=> openWindow(item, applicationManager)},
+      { "text": translationService.translate('BringToFront'), "action": () => bringItemFront(item, windowManager) },
+      pluginsDataService.pinContext(item),
+      { "text": translationService.translate('Properties'), "action": () => launchPluginPropertyWindow(item.plugin, windowManager) },
+      { "text": translationService.translate("Close All"), "action": ()=> closeAllWindows(item, windowManager)},
+    ];
+  } else if (item.instanceIds.length != 0) {
+    menuItems = [
+      { "text": translationService.translate("Open New"), "action": ()=> openWindow(item, applicationManager)},
+      pluginsDataService.pinContext(item),
+      { "text": translationService.translate('Properties'), "action": () => launchPluginPropertyWindow(item.plugin, windowManager) },
+      { "text": translationService.translate("Close All"), "action": ()=> closeAllWindows(item, windowManager)}
+    ];
+  } else {
+    menuItems =
+      [
+      { "text": translationService.translate('Open'), "action": () => openWindow(item, applicationManager) },
+      pluginsDataService.pinContext(item),
+      { "text": translationService.translate('Properties'), "action": () => launchPluginPropertyWindow(item.plugin, windowManager) },
+    ]
+  }
+  return menuItems;
+}


### PR DESCRIPTION
Fixed the following:
open-new was missing from within start menu
start menu didn't restore a minimized app when clicking the app icon when instance already open. 
add id to properties app, so you can refer to IDs more easily. 
clicking properties in right click menu does not focus properties app. 
cant re-use properties app (try to open properties for 2 different apps - doesnt do anything)

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>