### PR TITLE
Provide express-ws router function to dataservices

### DIFF
--- a/bootstrap/lib/notificationProxy.js
+++ b/bootstrap/lib/notificationProxy.js
@@ -23,7 +23,11 @@ exports.adminNotificationWebsocketRouter = function(context) {
 
 
     return new Promise(function(resolve, reject) {
-      let router = express.Router();  
+      let router = express.Router();
+      if (!router.ws) {
+        context.wsRouterPatcher(router);
+      }
+
       router.use(function abc(req,res,next) {
         context.logger.info('Saw Websocket request, method='+req.method);
         next();


### PR DESCRIPTION
See https://github.com/zowe/zlux-server-framework/pull/149 for where this object comes from: in case router.ws is missing (why?) it can be added by invoking a function from express-ws. Added to context for convenience & utilization without needing the "app" object.