### PR TITLE
Add option to control how iframe opens up in its own window

### DIFF
--- a/virtual-desktop/src/app/plugin-manager/shared/desktop-plugin-definition.ts
+++ b/virtual-desktop/src/app/plugin-manager/shared/desktop-plugin-definition.ts
@@ -36,6 +36,10 @@ export class DesktopPluginDefinitionImpl implements MVDHosting.DesktopPluginDefi
     this.key = basePlugin.getKey();
   }
 
+  get standaloneUseFramework(): boolean {
+    return !!this.basePlugin.getWebContent().standaloneUseFramework;
+  }
+
   get hasWebContent(): boolean {
     return this.basePlugin.getWebContent() != null;
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
@@ -69,9 +69,9 @@ function openWindow(item: LaunchbarItem, applicationManager: MVDHosting.Applicat
 }
 
 function openStandalone(item: LaunchbarItem): void {
-  const plginType:string = item.plugin.getFramework();
+  const pluginType:string = item.plugin.getFramework();
   //future TODO: initialize cross-window app2app communication??
-  if (plginType === 'iframe') {
+  if (pluginType === 'iframe' && !(item.plugin.standaloneUseFramework)) {
     // Still allows IFrames to comprehend URL parameters if address is copy/pasted later. Should not break any app2app possibilities
     window.open(`${location.origin}${(window as any).ZoweZLUX.uriBroker.pluginResourceUri(item.plugin, item.plugin.getBasePlugin().getWebContent().startingPage)}`);
   } else {


### PR DESCRIPTION
The MVS/USS/JES explorers used to need to open up directly to their own html in order to support certain query parameters for now, so to not disturb that yet to let other iframes open up with the framework intact as non-iframe plugins do, this adds a new optional attribute to the plugindefinition to state how you want the iframe to be handled. The attribute is named "standaloneUseFramework", and an example is here: https://github.com/zowe/sample-iframe-app/blob/staging/pluginDefinition.json#L9

Comparing the sample iframe app before and after, you can see how this attribute changes the URL that opens up when clicking the link on the desktop to "open in new tab".
https://imgur.com/a/nzBqogZ

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>