### PR TITLE
App scanning, plugin manager rewrite, log fixes

### DIFF
--- a/bootstrap/src/uri/dsm-uri.ts
+++ b/bootstrap/src/uri/dsm-uri.ts
@@ -100,11 +100,17 @@ export class DsmUri implements ZLUX.UriBroker {
     return this.pluginServletUri()+`?pluginResourceUri=${this.pluginRootUri(pluginDefinition)}/${relativePath}`
   }
 
-  pluginListUri(pluginType?: ZLUX.PluginType): string {
+  pluginListUri(pluginType?: ZLUX.PluginType, refresh?: boolean): string {
+    let query;
     if (pluginType === undefined) {
-      return this.pluginServletUri()+`?pluginType=all`
+      query = `plugins?type=all`;
+    } else {
+      query = `plugins?type=${pluginType}`
     }
-    return this.pluginServletUri()+`?pluginType=${pluginType}`
+    if (refresh) {
+      query += `&refresh=true`;
+    }
+    return `${this.serverRootUri(query)}`;
   }
 
   pluginWSUri(pluginDefinition: ZLUX.Plugin, serviceName:string, 

--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -114,11 +114,17 @@ export class MvdUri implements ZLUX.UriBroker {
     return `${this.pluginRootUri(pluginDefinition)}web/${relativePath}`;
   }
 
-  pluginListUri(pluginType?: ZLUX.PluginType): string {
+  pluginListUri(pluginType?: ZLUX.PluginType, refresh?: boolean): string {
+    let query;
     if (pluginType === undefined) {
-      return `${this.serverRootUri(`plugins?type=all`)}`;
+      query = `plugins?type=all`;
+    } else {
+      query = `plugins?type=${pluginType}`
     }
-    return `${this.serverRootUri(`plugins?type=${pluginType}`)}`;
+    if (refresh) {
+      query += `&refresh=true`;
+    }
+    return `${this.serverRootUri(query)}`;
   }
 
   pluginWSUri(plugin: ZLUX.Plugin, serviceName: string, relativePath: string,

--- a/bootstrap/web/iframe-adapter.js
+++ b/bootstrap/web/iframe-adapter.js
@@ -198,9 +198,10 @@ var ZoweZLUX = {
         getPlugin(id){
             return translateFunction('ZoweZLUX.pluginManager.getPlugin', [id])
         },
-        loadPlugins(pluginType){
-
+        loadPlugins(pluginType, update){
+            return translateFunction('ZoweZLUX.pluginManager.loadPlugins', Array.prototype.slice.call(arguments))
         },
+      /*  These are omitted because they do not seem like something an iframe should modify
         setDesktopPlugin(plugin){
 
         },
@@ -210,54 +211,55 @@ var ZoweZLUX = {
         getDesktopPlugin(){
 
         }
+      */
     },
     uriBroker: {
         desktopRootUri(){
             return translateFunction('ZoweZLUX.uriBroker.desktopRootUri', [])
         },
         datasetMetadataHlqUri(updateCache, types, workAreaSize, resumeName, resumeCatalogName){
-
+            return translateFunction('ZoweZLUX.uriBroker.datasetMetadataHlqUri', Array.prototype.slice.call(arguments))
         },
         datasetMetadataUri(dsn, detail, types, listMembers, workAreaSize, includeMigrated, includeUnprintable,
                                     resumeName, resumeCatalogName, addQualifiers){
-            
+          return translateFunction('ZoweZLUX.uriBroker.datasetMetadataUri', Array.prototype.slice.call(arguments))
         },
         datasetContentsUri(dsn){
-
+          return translateFunction('ZoweZLUX.uriBroker.datasetContentsUri', Array.prototype.slice.call(arguments))
         },
         VSAMdatasetContentsUri(dsn, closeAfter){
-
+          return translateFunction('ZoweZLUX.uriBroker.VSAMdatasetContentsUri', Array.prototype.slice.call(arguments))
         },
         unixFileUri(route, absPath, sourceEncodingOrOptions,
                             targetEncoding, newName, forceOverwrite, sessionID, lastChunk, responseType){
-
+          return translateFunction('ZoweZLUX.uriBroker.unixFileUri', Array.prototype.slice.call(arguments))
         },
         omvsSegmentUri(){
-
+          return translateFunction('ZoweZLUX.uriBroker.omvsSegmentUri', Array.prototype.slice.call(arguments))
         },
         rasUri(uri){
-
+          return translateFunction('ZoweZLUX.uriBroker.rasUri', Array.prototype.slice.call(arguments))
         },
         serverRootUri(uri){
-
+          return translateFunction('ZoweZLUX.uriBroker.serverRootUri', Array.prototype.slice.call(arguments))
         },
         pluginResourceUri(pluginDefinition, relativePath){
-
+          return translateFunction('ZoweZLUX.uriBroker.pluginResourceUri', Array.prototype.slice.call(arguments))
         },
-        pluginListUri(pluginType){
-
+        pluginListUri(pluginType, update){
+          return translateFunction('ZoweZLUX.uriBroker.pluginListUri', Array.prototype.slice.call(arguments))
         },
         pluginConfigForScopeUri(pluginDefinition, scope, resourcePath, resourceName){
-
+          return translateFunction('ZoweZLUX.uriBroker.pluginConfigForScopeUri', Array.prototype.slice.call(arguments))
         },
         pluginConfigUri(pluginDefinition, resourcePath, resourceName){
-            return translateFunction('ZoweZLUX.uriBroker.pluginConfigUri', [pluginDefinition, resourcePath, resourceName])
+            return translateFunction('ZoweZLUX.uriBroker.pluginConfigUri', Array.prototype.slice.call(arguments))
         },
         pluginWSUri(pluginDefinition, serviceName, relativePath, version){
-
+            return translateFunction('ZoweZLUX.uriBroker.pluginWSUri', Array.prototype.slice.call(arguments))
         },
         pluginRESTUri(pluginDefinition, serviceName, relativePath, version){
-            return translateFunction('ZoweZLUX.uriBroker.pluginRESTUri', [pluginDefinition, serviceName, relativePath, version])
+            return translateFunction('ZoweZLUX.uriBroker.pluginRESTUri', Array.prototype.slice.call(arguments))
         }
     },
     dispatcher: {
@@ -350,7 +352,7 @@ var windowActions = {
         return translateFunction('windowActions.restore', [])
     },
     setTitle(title){
-        return translateFunction('windowActions.setTitle', [title])
+        return translateFunction('windowActions.setTitle', Array.prototype.slice.call(arguments))
     },
     setPosition(pos){
         return translateFunction('windowActions.setPosition', [pos])

--- a/virtual-desktop/pluginDefinition.json
+++ b/virtual-desktop/pluginDefinition.json
@@ -33,8 +33,6 @@
         }
       },
       "session": {
-        //this could be used to configure activity idle timeout, time to warn before expiration, and more
-        //as well as max and min username and password lengths, or if another means is being used
         "subResources": {
           "security": {
             "aggregationPolicy": "none",

--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -217,7 +217,8 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
           let languageCode = this.l10nConfigService.getDefaultLocale().languageCode; // Figure out the desktop language
           let messageLoc = ZoweZLUX.uriBroker.pluginResourceUri(plugin.getBasePlugin(), `assets/i18n/log/messages_${languageCode}.json`);
           this.http.get(messageLoc).subscribe( // Try to load log messages of desired language
-          messages => {
+            messages => {
+              if (languageCode != 'en') {
               let messageLocEN = ZoweZLUX.uriBroker.pluginResourceUri(plugin.getBasePlugin(), `assets/i18n/log/messages_en.json`);
               this.http.get(messageLocEN).subscribe( // Try to load English log messages
                 messagesEN => {
@@ -227,8 +228,11 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
                 error => { // If English is not found, just return the previously obtained messages.
                   resolve(this.generateInjectorAfterCheckingForLoggerMessages(compiled, plugin, launchMetadata, applicationInstance, viewportId, messages));
                 });
+              } else {
+                resolve(this.generateInjectorAfterCheckingForLoggerMessages(compiled, plugin, launchMetadata, applicationInstance, viewportId, messages));
+              }
           }, error => {
-            if (error.status = 404) { // If log messages are not available in desired language,
+            if (error.status = 404 && languageCode != 'en') { // If log messages are not available in desired language,
               let messageLocEN = ZoweZLUX.uriBroker.pluginResourceUri(plugin.getBasePlugin(), `assets/i18n/log/messages_en.json`); // Default to English
               this.http.get(messageLocEN).subscribe( // ...try English.
                 messages => {
@@ -236,6 +240,8 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
                 }, error => { // In all other cases, load the logger without messages.
                   resolve(this.generateInjectorAfterCheckingForLoggerMessages(compiled, plugin, launchMetadata, applicationInstance, viewportId, null));
                 });
+            } else {
+              resolve(this.generateInjectorAfterCheckingForLoggerMessages(compiled, plugin, launchMetadata, applicationInstance, viewportId, null));
             }
           });
         }

--- a/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
+++ b/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
@@ -66,7 +66,6 @@ export class AuthenticationManager {
     public http: Http,
     private injector: Injector,
     private pluginManager: PluginManager
-
   ) {
     this.log = BaseLogger.makeSublogger("auth");
     this.username = null;
@@ -75,7 +74,6 @@ export class AuthenticationManager {
     this.registerPreLogoutAction(new ClearZoweZLUX());
     this.registerPreLogoutAction(this.pluginManager)
     this.registerPostLoginAction(new initializeNotificationManager());
-    this.registerPostLoginAction(this.pluginManager);
     this.loginScreenVisibilityChanged = new EventEmitter();
     this.loginExpirationIdleCheck = new EventEmitter();
   }
@@ -155,8 +153,9 @@ export class AuthenticationManager {
   }
 
   private performPostLoginActions(): Observable<any> {
-    return new Observable((observer)=> {      
-      ZoweZLUX.pluginManager.loadPlugins(ZLUX.PluginType.Application).then((plugins:ZLUX.Plugin[])=> {
+    return new Observable((observer)=> {
+      this.pluginManager.loadApplicationPluginDefinitions().then((pluginDefs:MVDHosting.DesktopPluginDefinition[])=> {
+        let plugins = pluginDefs.map(plugin => plugin.getBasePlugin());
         if (this.username != null) {
           for (let i = 0; i < this.postLoginActions.length; i++) {
             let success = this.postLoginActions[i].onLogin(this.username, plugins);

--- a/virtual-desktop/src/app/plugin-manager/shared/plugin-manager.ts
+++ b/virtual-desktop/src/app/plugin-manager/shared/plugin-manager.ts
@@ -10,60 +10,79 @@
   Copyright Contributors to the Zowe Project.
 */
 
-import { Injectable } from '@angular/core';
+import { Injectable, EventEmitter } from '@angular/core';
 
 import { DesktopPluginDefinitionImpl } from './desktop-plugin-definition';
 import { PluginLoader } from './plugin-loader';
 
+const SCAN_INTERVAL = 300000;
+
 @Injectable()
 export class PluginManager implements MVDHosting.PluginManagerInterface, MVDHosting.LoginActionInterface, MVDHosting.LogoutActionInterface {
-  private _pluginDefinitions: Map<string, MVDHosting.DesktopPluginDefinition>;
+  private static _pluginDefinitions: Map<string, MVDHosting.DesktopPluginDefinition> = new Map();
+  private static _scanner: any;
+
+  public pluginsAdded: EventEmitter<MVDHosting.DesktopPluginDefinition[]> = new EventEmitter();
 
   constructor(
     private pluginLoader: PluginLoader
   ) {
-    this.loadApplicationPluginDefinitionsMap();
   }
 
-  onLogin(): boolean {
-    this._pluginDefinitions.clear();
-    this.loadApplicationPluginDefinitionsMap();
+  onLogin(plugins:any): boolean {
+    PluginManager._scanner = setInterval(()=> {
+      this.updateMap();
+    },SCAN_INTERVAL);
     return true;
   }
-
+  
   onLogout(): boolean {
-    this._pluginDefinitions.clear();
+    if (PluginManager._scanner) {
+      clearInterval(PluginManager._scanner);
+    }
+    PluginManager._pluginDefinitions.clear();
     return true;
   }
 
-  loadApplicationPluginDefinitions(): Promise<MVDHosting.DesktopPluginDefinition[]> {
-    if (this._pluginDefinitions != null) {
-      if (this._pluginDefinitions.size != 0) {
-        return Promise.resolve(Array.from(this._pluginDefinitions.values()));
+  loadApplicationPluginDefinitions(update?:boolean): Promise<MVDHosting.DesktopPluginDefinition[]> {
+    if (!update && PluginManager._pluginDefinitions != null) {
+      if (PluginManager._pluginDefinitions.size != 0) {
+        return Promise.resolve(Array.from(PluginManager._pluginDefinitions.values()));
       }
     }
-    return ZoweZLUX.pluginManager.loadPlugins('application')
-      .then((plugins: ZLUX.Plugin[]) => plugins.map(plugin => new DesktopPluginDefinitionImpl(plugin)));
+    return ZoweZLUX.pluginManager.loadPlugins('application', update)
+      .then((plugins: ZLUX.Plugin[]) => {
+        if (PluginManager._pluginDefinitions.size != 0) {
+          plugins = plugins.filter(plugin => !PluginManager._pluginDefinitions.get(plugin.getIdentifier()))
+        }
+        const pluginDefs = plugins.map(plugin => new DesktopPluginDefinitionImpl(plugin));
+        pluginDefs.forEach((plugin) => PluginManager._pluginDefinitions.set(plugin.getIdentifier(), plugin));
+        pluginDefs.forEach((plugin) => this.pluginLoader.loadPluginComponentFactories(plugin));
+        if (pluginDefs.length > 0) {
+          this.pluginsAdded.emit(pluginDefs);
+        }
+        return pluginDefs;
+      });
   }
 
-  loadApplicationPluginDefinitionsMap(): Promise<Map<string, MVDHosting.DesktopPluginDefinition>> {
-    if (this._pluginDefinitions != null) {
-      if (this._pluginDefinitions.size != 0) {
-        return Promise.resolve(this._pluginDefinitions);
+  loadApplicationPluginDefinitionsMap(update?:boolean): Promise<Map<string, MVDHosting.DesktopPluginDefinition>> {
+    if (!update && PluginManager._pluginDefinitions != null) {
+      if (PluginManager._pluginDefinitions.size != 0) {
+        return Promise.resolve(PluginManager._pluginDefinitions);
       }
     }
     return this.loadApplicationPluginDefinitions()
       .then((plugins: MVDHosting.DesktopPluginDefinition[]) => {
-        const map = new Map();
-        plugins.forEach((plugin) => map.set(plugin.getIdentifier(), plugin));
-        plugins.forEach((plugin) => this.pluginLoader.loadPluginComponentFactories(plugin));
-        this._pluginDefinitions = map;
-      })
-      .then(() => this._pluginDefinitions);
+        return PluginManager._pluginDefinitions;
+      });
   }
 
-  findPluginDefinition(identifier: string): Promise<MVDHosting.DesktopPluginDefinition | null> {
-    return this.loadApplicationPluginDefinitionsMap().then(map => map.get(identifier) || null);
+  updateMap(): Promise<Map<string, MVDHosting.DesktopPluginDefinition>> {
+    return this.loadApplicationPluginDefinitionsMap(true);
+  }
+
+  findPluginDefinition(identifier: string, update?:boolean): Promise<MVDHosting.DesktopPluginDefinition | null> {
+    return this.loadApplicationPluginDefinitionsMap(update).then(map => map.get(identifier) || null);
   }
 }
 

--- a/virtual-desktop/src/app/plugin-manager/shared/plugin-manager.ts
+++ b/virtual-desktop/src/app/plugin-manager/shared/plugin-manager.ts
@@ -15,10 +15,10 @@ import { Injectable, EventEmitter } from '@angular/core';
 import { DesktopPluginDefinitionImpl } from './desktop-plugin-definition';
 import { PluginLoader } from './plugin-loader';
 
-const SCAN_INTERVAL = 300000;
+const SCAN_INTERVAL_MINIMUM = 300000;
 
 @Injectable()
-export class PluginManager implements MVDHosting.PluginManagerInterface, MVDHosting.LoginActionInterface, MVDHosting.LogoutActionInterface {
+export class PluginManager implements MVDHosting.PluginManagerInterface, MVDHosting.LogoutActionInterface {
   private static _pluginDefinitions: Map<string, MVDHosting.DesktopPluginDefinition> = new Map();
   private static _scanner: any;
 
@@ -29,11 +29,28 @@ export class PluginManager implements MVDHosting.PluginManagerInterface, MVDHost
   ) {
   }
 
-  onLogin(plugins:any): boolean {
-    PluginManager._scanner = setInterval(()=> {
-      this.updateMap();
-    },SCAN_INTERVAL);
-    return true;
+  unsetScanner(): boolean {
+    return this.setScanInterval(0);
+  }
+
+  setScanInterval(ms: number): boolean {
+    if (ms <= 0) {
+      if (PluginManager._scanner) {
+        clearInterval(PluginManager._scanner);
+      }
+      return true;
+    }
+
+    if (ms >= SCAN_INTERVAL_MINIMUM) {
+      if (PluginManager._scanner) {
+        clearInterval(PluginManager._scanner);
+      }
+      PluginManager._scanner = setInterval(()=> {
+        this.updateMap();
+      },ms);
+      return true;      
+    }
+    return false;
   }
   
   onLogout(): boolean {

--- a/virtual-desktop/src/app/shared/logger.ts
+++ b/virtual-desktop/src/app/shared/logger.ts
@@ -21,20 +21,23 @@ fetch(messageLoc) // Attempt to find log messages for global language
     BaseLogger._messages = messages;
     afterBaseLoggerInit();
 })
-.catch(function() { // If it doesn't work...
-    lang = "en"; // Try English log messages (default)
-    messageLoc = ZoweZLUX.uriBroker.pluginResourceUri(plugin, `assets/i18n/log/messages_${lang}.json`);
+  .catch(function() { // If it doesn't work...
+    if (lang != 'en') {
+      lang = "en"; // Try English log messages (default)
+      messageLoc = ZoweZLUX.uriBroker.pluginResourceUri(plugin, `assets/i18n/log/messages_${lang}.json`);
 
-    fetch(messageLoc)
-    .then((resp) => resp.json())
-    .then(function(messages) {
-        BaseLogger._messages = messages;
-        afterBaseLoggerInit();
-    })
-    .catch(function() { // If that still doesn't work, just do nothing...
+      fetch(messageLoc)
+        .then((resp) => resp.json())
+        .then(function(messages) {
+          BaseLogger._messages = messages;
+          afterBaseLoggerInit();
+        })
+        .catch(function() { // If that still doesn't work, just do nothing...
+          afterBaseLoggerInit();
+        });
+    } else {
       afterBaseLoggerInit();
-    });
-
+    }
 });
 
 function afterBaseLoggerInit() {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.css
@@ -17,6 +17,25 @@
   background-image: url("../../../../../assets/images/launchbar/more-apps.png");
 }
 
+.launch-menu-search {
+  position:absolute;
+  bottom: 5px;
+  width: 100%;
+}
+
+.launch-menu-scroller {
+  overflow-y: scroll;
+  width: 315px;
+  height: 295px;
+  bottom: 31px;
+  position: absolute;
+  background: #dde8f1;
+}
+
+.refresh-plugins {
+  float:right;  
+}
+
 .launch-widget {
   height: 100%;
   width: 125px;
@@ -71,9 +90,9 @@
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
   background: #dde8f1;
-  padding: 30px;
-  overflow-y: scroll;
+  padding: 5px 10px 0px 10px;
 }
+
 
 .launchbar-separator-hor {
   color: #36617a;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
@@ -20,11 +20,20 @@
     <!-- <div class="launch-widget-row" (click)="personalizationPanelToggle()">
         <img class="icon" src="/ZLUX/plugins/org.zowe.zlux.ng2desktop.settings/web/assets/Settings2.png">
         <p>Preferences</p>
+    </div -->
+    <div style="cursor: pointer" class="refresh-plugins" (click)="refresh()">
+      Refresh applications
+      <i style="padding: 5px" class="fa fa-refresh" (click)="refresh()"></i>
     </div>
-    <hr class="launchbar-separator-hor"> -->
-    <div class="launch-widget-row" *ngFor="let item of menuItems" (click)="clicked(item)" [title]="item.tooltip" (contextmenu)="onRightClick($event, item)">
-      <img class="icon" [src]="item.image">
-      <p>{{item.label}}</p>
+    <div style="margin: 20px"></div>
+    <div class="launch-menu-scroller">
+      <div class="launch-widget-row" *ngFor="let item of displayItems" (click)="clicked(item)" [title]="item.tooltip" (contextmenu)="onRightClick($event, item)">
+        <img class="icon" [src]="item.image">
+        <p>{{item.label}}</p>
+      </div>
+    </div>
+    <div class="launch-menu-search">
+      <input style="width:95%" type="text" placeholder="Search Applications" [(ngModel)]="appFilter" (input)="filterMenuItems()">
     </div>
   </div>
   <div class="launch-widget-caret caret-down"></div>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar.module.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar.module.ts
@@ -12,7 +12,7 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
+import { FormsModule } from '@angular/forms';
 import { SharedModule } from 'app/shared/shared.module';
 
 import { LaunchbarComponent } from './launchbar/launchbar.component';
@@ -30,6 +30,7 @@ import {MAT_SNACK_BAR_DATA} from '@angular/material';
     CommonModule,
     SharedModule,
     MatSnackBarModule,
+    FormsModule
   ],
   declarations: [
     LaunchbarComponent,

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
@@ -11,7 +11,7 @@
 -->
 
 <div class="launchbar-container launchbar-large" id="container" (mouseup)="onMouseUpContainer($event)" [class.active]="isActive">
-  <rs-com-launchbar-menu [menuItems]="allItems" (itemClicked)="menuItemClicked($event)"  (refreshClicked)="getNewItems(true)" (menuStateChanged)="onStateChanged($event)"></rs-com-launchbar-menu>
+  <rs-com-launchbar-menu [menuItems]="allItems" (itemClicked)="menuItemClicked($event)"  (refreshClicked)="getNewItems()" (menuStateChanged)="onStateChanged($event)"></rs-com-launchbar-menu>
   <div class="launchbar">
     <rs-com-launchbar-icon *ngFor="let item of pinnedItems" [launchbarItem]="item" (contextmenu)="onRightClick($event, item)"
     (mousedown)="onMouseDown($event, item)" (mousemove)="onMouseMove($event, item)">

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
@@ -11,7 +11,7 @@
 -->
 
 <div class="launchbar-container launchbar-large" id="container" (mouseup)="onMouseUpContainer($event)" [class.active]="isActive">
-  <rs-com-launchbar-menu [menuItems]="allItems" (itemClicked)="menuItemClicked($event)"  (menuStateChanged)="onStateChanged($event)"></rs-com-launchbar-menu>
+  <rs-com-launchbar-menu [menuItems]="allItems" (itemClicked)="menuItemClicked($event)"  (refreshClicked)="getNewItems(true)" (menuStateChanged)="onStateChanged($event)"></rs-com-launchbar-menu>
   <div class="launchbar">
     <rs-com-launchbar-icon *ngFor="let item of pinnedItems" [launchbarItem]="item" (contextmenu)="onRightClick($event, item)"
     (mousedown)="onMouseDown($event, item)" (mousemove)="onMouseMove($event, item)">

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -42,6 +42,7 @@ export class LaunchbarComponent {
   helperLoggedIn: boolean;
   private applicationManager: MVDHosting.ApplicationManagerInterface;
   private authenticationManager: MVDHosting.AuthenticationManagerInterface;
+  private pluginManager: MVDHosting.PluginManagerInterface;
   propertyWindowPluginDef: DesktopPluginDefinitionImpl;
   
    constructor(
@@ -53,31 +54,28 @@ export class LaunchbarComponent {
      // Workaround for AoT problem with namespaces (see angular/angular#15613)
      this.applicationManager = this.injector.get(MVDHosting.Tokens.ApplicationManagerToken);
      this.authenticationManager = this.injector.get(MVDHosting.Tokens.AuthenticationManagerToken);
+     this.pluginManager = this.injector.get(MVDHosting.Tokens.PluginManagerToken);
      this.allItems = [];
      this.runItems = [];
      this.isActive = false;
      this.contextMenuRequested = new Subject();
      this.loggedIn = false;
      this.helperLoggedIn = false; //helperLoggedIn is to indicate when the initial login happens
+     this.pluginManager.pluginsAdded.subscribe((plugins:MVDHosting.DesktopPluginDefinition[])=> {
+       plugins.forEach((p: any)=> {
+         let pluginDef = p.getBasePlugin().getBasePlugin();
+         if (pluginDef.identifier === 'org.zowe.zlux.appmanager.applugin.propview') {
+           this.propertyWindowPluginDef = p;
+         } else if (!pluginDef.isSystemPlugin && pluginDef.webContent) {
+           this.allItems.push(new PluginLaunchbarItem(p, this.windowManager));
+         }
+       });
+       this.pluginsDataService.refreshPinnedPlugins(this.allItems);
+     });
    }
-  
-  getAllItems(): void {
-    this.allItems = [];
-    ZoweZLUX.pluginManager.loadPlugins('application').then((plugins: Plugin[]) => {
-      plugins.forEach((p: any)=> {
-        if (p.webContent != null) {
-          if (p.identifier === 'org.zowe.zlux.appmanager.app.propview') {
-            const pluginImpl:DesktopPluginDefinitionImpl = p as DesktopPluginDefinitionImpl;
-            this.propertyWindowPluginDef = pluginImpl;
-          } else if (p.identifier === 'org.zowe.zlux.ng2desktop.settings') { 
-            // UI decision made to not display Settings application with the main application menu.
-            // The Settings apps will be accessible via their own dedicated panel, and need not hog the menu.
-          } else {
-            this.allItems.push(new PluginLaunchbarItem(new DesktopPluginDefinitionImpl(p), this.windowManager));
-          }
-        }
-      })
-    });
+
+  getNewItems(): void {
+    this.pluginManager.loadApplicationPluginDefinitions(true);
   }
 
   ngDoCheck(): void {
@@ -89,11 +87,7 @@ export class LaunchbarComponent {
       this.helperLoggedIn = false;
     }
     if (this.loggedIn) {
-      if(this.helperLoggedIn != true){
-        this.getAllItems();
-        this.pluginsDataService.refreshPinnedPlugins(this.allItems);
-        this.helperLoggedIn = true;
-      }
+      this.helperLoggedIn = true;
     }
   }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/mvd.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/mvd.component.ts
@@ -19,7 +19,6 @@ import { Component } from '@angular/core';
 export class MvdComponent {
 
   constructor() {
-
   }
 }
 

--- a/virtual-desktop/src/externals.ts
+++ b/virtual-desktop/src/externals.ts
@@ -17,9 +17,6 @@
   waitSeconds: 0
 });
 
-import { BaseLogger } from 'virtual-desktop-logger';
-const logger: ZLUX.ComponentLogger = BaseLogger;
-
 /* These will be packaged into a single bundle by the webpack bundling system.
  * We then expose them to our module loader (requirejs) manually and use that
  * to load the desktop and external plugins. These requires use webpack. */
@@ -46,7 +43,7 @@ for (const library in libs) {
   if (libs[library]) {
     (window as any).define(library, libs[library]);
   } else {
-    logger.warn(`Missing library ${library}`);
+    console.warn(`Missing library ${library}`);
   }
 }
 


### PR DESCRIPTION
- Loggers tried to load english twice if english was the language of choice
- Plugin managers did not cache effectively, leading to repeat server calls for same info
- Small new feature: filter apps by typing
- Big new feature: scan for and add new apps to the desktop as they become available on the server (depends on https://github.com/zowe/zlux-server-framework/pull/179)

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>