### PR TITLE
Add lang hint to html head based on user preference as soon as known

### DIFF
--- a/virtual-desktop/src/app/i18n/language-locale.service.ts
+++ b/virtual-desktop/src/app/i18n/language-locale.service.ts
@@ -27,6 +27,8 @@ export class LanguageLocaleService {
 
   constructor(
   ) {
+    const lang = this.getLanguage();
+    document.documentElement.lang = lang;
   }
 
   getLanguage(): string {


### PR DESCRIPTION
This could have detrimental effects if the apps do not support the language and do not specify otherwise.
Try testing the editor versus the sample angular app to compare how japanese operates, for example.

Made for testing with https://github.com/zowe/zlux/issues/394
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>