### PR TITLE
[WIP] State Persistance Mechanism

### DIFF
--- a/bootstrap/web/iframe-adapter.js
+++ b/bootstrap/web/iframe-adapter.js
@@ -91,6 +91,10 @@ let messageHandler = function(message) {
                 let sessionExpire = new CustomEvent('ZoweZLUX.sessionEvents', {detail: {event:'sessionExpire'}});
                 window.dispatchEvent(sessionExpire);
                 return;
+            case 'sessionEvents.saveData':
+                let saveData = new CustomEvent('ZoweZLUX.sessionEvents', {detail: {event:'saveData'}});
+                window.dispatchEvent(saveData);
+                return;
             default:
                 return;
         }

--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -26,6 +26,7 @@ import { EmbeddedInstance } from 'pluginlib/inject-resources';
 import { BaseLogger } from 'virtual-desktop-logger';
 import { IFRAME_NAME_PREFIX, INNER_IFRAME_NAME } from '../shared/named-elements';
 import { L10nConfigService } from '../i18n/l10n-config.service';
+import {EventEmitter} from '@angular/core';
 
 @Injectable()
 export class ApplicationManager implements MVDHosting.ApplicationManagerInterface {
@@ -34,6 +35,7 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
   private nextInstanceId: MVDHosting.InstanceId;
   private readonly logger: ZLUX.ComponentLogger = BaseLogger;
   private knownLoggerMessageChecks: string[];
+  readonly saveApplicationData: EventEmitter<MVDHosting.saveApplicationDataDefaults>;
 
   constructor(
     private injector: Injector,
@@ -45,6 +47,8 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
     private l10nConfigService: L10nConfigService,
     private http: HttpClient,
   ) {
+    this.saveApplicationData = new EventEmitter();
+    setInterval(()=> { this.saveApplicationData.emit(MVDHosting.saveApplicationDataDefaults.saveDataInterval) }, MVDHosting.saveApplicationDataDefaults.saveDataInterval);
     this.failureModuleFactory = this.compiler.compileModuleSync(FailureModule);
     this.applicationInstances = new Map();
     this.knownLoggerMessageChecks = [];

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin.component.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin.component.ts
@@ -108,13 +108,16 @@ export class IFramePluginComponent {
       });
       this.themeEvents.colorChanged.subscribe(() => {
         this.postWindowEvent('themeEvents.colorChanged')
-      })
+      });
       this.themeEvents.sizeChanged.subscribe(() => {
         this.postWindowEvent('themeEvents.sizeChanged')
-      })
+      });
       this.themeEvents.wallpaperChanged.subscribe(() => {
         this.postWindowEvent('themeEvents.wallpaperChanged')
-      })
+      });
+      this.sessionEvents.saveData.subscribe(() => {
+        this.postWindowEvent('sessionEvents.saveData')
+      });
       return;
     }
     if(data.request.instanceId === this.instanceId){

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -170,6 +170,11 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         }
       })
     });
+    this.applicationManager.saveApplicationData.subscribe((saveApplicationDataDefaults: MVDHosting.saveApplicationDataDefaults) => {
+      this.sessionSubscriptions.forEach((session: Angular2PluginSessionEvents, winddowId: MVDWindowManagement.WindowId) => {
+        session.saveData.next();
+      })
+    });
   }
 
   public static _setTheme(newTheme: DesktopTheme) {
@@ -432,9 +437,11 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private generateSessionEventsProvider(windowId: MVDWindowManagement.WindowId): Angular2PluginSessionEvents {
     const login = new Subject<void>();
     const sessionExpire = new Subject<void>();
+    const saveData = new Subject<void>();
     const sessionEvents: Angular2PluginSessionEvents = {
       login,
-      sessionExpire
+      sessionExpire,
+      saveData
     }
     this.sessionSubscriptions.set(windowId, sessionEvents)
     return sessionEvents

--- a/virtual-desktop/src/app/window-manager/simple-window-manager/simple-window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/simple-window-manager/simple-window-manager.service.ts
@@ -93,6 +93,7 @@ export class SimpleWindowManagerService implements MVDWindowManagement.WindowMan
   private generateSessionEventsProvider(): Angular2PluginSessionEvents {
     const loginSubject = new Subject<void>();
     const sessionExpireSubject = new Subject<void>();
+    const saveDataSubject = new Subject<void>();
     this.authenticationManager.loginScreenVisibilityChanged.subscribe((eventReason: MVDHosting.LoginScreenChangeReason) => {
       switch (eventReason) {
         case MVDHosting.LoginScreenChangeReason.UserLogin:
@@ -104,9 +105,13 @@ export class SimpleWindowManagerService implements MVDWindowManagement.WindowMan
       default:
       }
     });
+    this.applicationManager.saveApplicationData.subscribe((saveApplicationDataDefaults: MVDHosting.saveApplicationDataDefaults) => {
+        saveDataSubject.next();
+    });
     return {
       login: loginSubject,
-      sessionExpire: sessionExpireSubject
+      sessionExpire: sessionExpireSubject,
+      saveData: saveDataSubject
     };
   }
 

--- a/virtual-desktop/src/pluginlib/inject-resources.ts
+++ b/virtual-desktop/src/pluginlib/inject-resources.ts
@@ -56,6 +56,7 @@ export interface Angular2PluginWindowActions {
 export interface Angular2PluginSessionEvents {
   readonly login: Subject<void>;
   readonly sessionExpire: Subject<void>;
+  readonly saveData: Subject<void>;
 }
 
 export interface Angular2PluginThemeEvents {


### PR DESCRIPTION
Add SaveData Event for Zowe Desktop State Persistance Mechanism

zlux-platform PR for MVDHosting changes: https://github.com/zowe/zlux-platform/pull/61 

**Angular Example**
```
constructor( @Inject(Angular2InjectionTokens.SESSION_EVENTS) private sessionEvents: Angular2PluginSessionEvents){

this.sessionEvents.saveData.subscribe(()=> {
      this.log.warn("Inside sample angular app, Parameters are:" + this.parameters)
 })

}
```
**React Example:**
Retrieve the sessionEvents from the resources props
`
this.sessionEvents = this.props.resources.sessionEvents;
`

Then listen on the appropriate event:
```

this.sessionEvents.saveData.subscribe(() =>{
    console.log("Sample React App")
})
```



