### PR TITLE
Example of how to issue an event which can accept a response

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -432,9 +432,23 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private generateSessionEventsProvider(windowId: MVDWindowManagement.WindowId): Angular2PluginSessionEvents {
     const login = new Subject<void>();
     const sessionExpire = new Subject<void>();
+    const autosaveEmitter = new Subject<any>();
+    let thing: DesktopWindow|undefined = this.windowMap.get(windowId);
+    if (thing) {
+    let plugin: ZLUX.Plugin = thing.plugin;
+      setInterval(()=> {
+        autosaveEmitter.next((data:any)=> {
+          console.log('I should save plugins data.');
+          console.log('plugin=',plugin);
+          console.log('windowId=',windowId);
+          console.log('data=',data);
+        });
+      },5000); 
+    }
     const sessionEvents: Angular2PluginSessionEvents = {
       login,
-      sessionExpire
+      sessionExpire,
+      autosaveEmitter
     }
     this.sessionSubscriptions.set(windowId, sessionEvents)
     return sessionEvents

--- a/virtual-desktop/src/app/window-manager/simple-window-manager/simple-window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/simple-window-manager/simple-window-manager.service.ts
@@ -93,6 +93,7 @@ export class SimpleWindowManagerService implements MVDWindowManagement.WindowMan
   private generateSessionEventsProvider(): Angular2PluginSessionEvents {
     const loginSubject = new Subject<void>();
     const sessionExpireSubject = new Subject<void>();
+    const autosaveEmitter = new Subject<any>();
     this.authenticationManager.loginScreenVisibilityChanged.subscribe((eventReason: MVDHosting.LoginScreenChangeReason) => {
       switch (eventReason) {
         case MVDHosting.LoginScreenChangeReason.UserLogin:
@@ -106,7 +107,8 @@ export class SimpleWindowManagerService implements MVDWindowManagement.WindowMan
     });
     return {
       login: loginSubject,
-      sessionExpire: sessionExpireSubject
+      sessionExpire: sessionExpireSubject,
+      autosaveEmitter: autosaveEmitter
     };
   }
 

--- a/virtual-desktop/src/pluginlib/inject-resources.ts
+++ b/virtual-desktop/src/pluginlib/inject-resources.ts
@@ -56,6 +56,7 @@ export interface Angular2PluginWindowActions {
 export interface Angular2PluginSessionEvents {
   readonly login: Subject<void>;
   readonly sessionExpire: Subject<void>;
+  readonly autosaveEmitter: Subject<any>;
 }
 
 export interface Angular2PluginThemeEvents {


### PR DESCRIPTION
Answers the question of how could the desktop issue a contextual to an app, and expect a response.
An alternative way to provide this event-and-response scheme could have used ZoweZLUX, but an Injectable is a bit better because it makes it easier to keep the data private between the framework and each app.
A security concern in general is to prevent the response from coming from code that was not the intended receiver of the event: you want to prevent man in the middle attacks & impostors.

How it works: The framework knows about the app, and therefore sends an event to an app which contains a function that when called, will return to the scope of the framework in the area that the framework knows about the app.  Because the event and its callback contain no information about the app, nothing is sent which can be stolen. Additionally, an Injectable is not shared between instances or apps, so privacy is maintained in both ways.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>