### PR TITLE
Remove webpack requirement

### DIFF
--- a/virtual-desktop/plugin-config/webpack.base.js
+++ b/virtual-desktop/plugin-config/webpack.base.js
@@ -10,7 +10,6 @@
   Copyright Contributors to the Zowe Project.
 */
 
-var webpack = require('webpack');
 var path = require('path');
 var os = require('os');
 


### PR DESCRIPTION
Webpack is needed to get to this point so the req is not needed

Signed-off-by: Suneeth Keerthy <skeerthy@rocketsoftware.com>