### PR TITLE
Remove double slash for unix api in case it is accidentally done

### DIFF
--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -49,7 +49,7 @@ export class MvdUri implements ZLUX.UriBroker {
     let routeParam = route;
     let absPathParam = encodeURIComponent(absPath).replace(/\%2F/gi,'/');
     
-    return `${this.serverRootUri(`unixfile/${routeParam}/${absPathParam}${params}`)}`;
+    return `${this.serverRootUri(`unixfile/${routeParam}/${absPathParam}${params}`)}`.replace(/\/\//g,'/');
   }
   omvsSegmentUri(): string {
     return `${this.serverRootUri('omvs')}`;


### PR DESCRIPTION
I found a place in the editor where double slash was being used, but rather than fix one app, this may fix many more apps in the future.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>