### PR TITLE
Make idle check only happen if session is renewable

### DIFF
--- a/virtual-desktop/src/app/authentication-manager/auth-capabilities.ts
+++ b/virtual-desktop/src/app/authentication-manager/auth-capabilities.ts
@@ -1,0 +1,31 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+export interface AuthCapabilities {
+  canAuthenticate: boolean;
+  canAuthorize: boolean;
+  canGetStatus: boolean;
+  canLogout: boolean;
+  canRefresh: boolean;
+  canResetPassword: boolean;
+  processesProxyHeaders: boolean;
+  proxyAuthorizations: boolean;
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+

--- a/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
+++ b/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
@@ -17,6 +17,7 @@ import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { BaseLogger } from 'virtual-desktop-logger';
 import { PluginManager } from 'app/plugin-manager/shared/plugin-manager';
 import { StartURLManager } from '../start-url-manager';
+import { AuthCapabilities } from './auth-capabilities';
 
 class ClearZoweZLUX implements MVDHosting.LogoutActionInterface {
   onLogout(username: string | null): boolean {
@@ -195,6 +196,7 @@ export class AuthenticationManager {
     }
     clearTimeout(this.expirationWarning);
     this.nearestExpiration = -1;
+    let canRefresh = true;
     let expirations = new Map<string,number>();
     let now = Date.now();
     for (let key in categories) {
@@ -207,6 +209,16 @@ export class AuthenticationManager {
             nearestExpirationForCategory = plugin.expms;
             if (this.nearestExpiration == -1 || this.nearestExpiration > nearestExpirationForCategory) {
               this.nearestExpiration = nearestExpirationForCategory;
+              // if the response does not include capabilities or capabilities.canRefresh
+              // we should assume true
+              // because a popup that fails is better than expiration when refresh is possible
+              canRefresh = true;
+              if (typeof plugin.capabilities === 'object') {
+                const capabilities: Partial<AuthCapabilities> = plugin.capabilities;
+                if (typeof capabilities.canRefresh === 'boolean') {
+                  canRefresh = capabilities.canRefresh;
+                }
+              }
             }
           }
         }
@@ -224,8 +236,12 @@ export class AuthenticationManager {
       this.expirationWarning = setTimeout(()=> {       
         this.log.info(`ZWED5022W`, logoutAfterWarnTimer/1000); /*this.log.info(`Session will expire soon! Logout will occur in ${logoutAfterWarnTimer/1000} seconds.`);*/
         this.log.debug("ZWED5301I", this.expirations); //this.log.debug(`Session expirations=`,this.expirations);
-        this.loginExpirationIdleCheck.emit({shortestSessionDuration: this.nearestExpiration,
-                                            expirationInMS: logoutAfterWarnTimer});
+        if (canRefresh) {
+          this.loginExpirationIdleCheck.emit({
+            shortestSessionDuration: this.nearestExpiration,
+            expirationInMS: logoutAfterWarnTimer
+          });
+        }
         this.expirationWarning = setTimeout(()=> {
           this.log.warn("ZWED5162W"); //this.log.warn(`Session timeout reached. Clearing desktop for new login.`);
           this.doLogoutInner(MVDHosting.LoginScreenChangeReason.SessionExpired);


### PR DESCRIPTION
Make idle check only happen if session is renewable. If the plugin doesn't state its capabilities we assume that session is renewable.

Depends on: https://github.com/zowe/zlux-server-framework/pull/234