### PR TITLE
Uribroker unixfile 3+ slash bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux App Manager will be documented in this file.
 
 ## `1.14.0`
 
+- [D] Fixed case in which the URI broker for unixfile would allow 3 or more slashes in a row
 - Fixed GET call for recognizers & actions such that they are loaded into dispatcher
 
 ## `1.13.0`

--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -49,7 +49,7 @@ export class MvdUri implements ZLUX.UriBroker {
     let routeParam = route;
     let absPathParam = encodeURIComponent(absPath).replace(/\%2F/gi,'/');
     
-    return `${this.serverRootUri(`unixfile/${routeParam}/${absPathParam}${params}`)}`.replace(/\/\//g,'/');
+    return `${this.serverRootUri(`unixfile/${routeParam}/${absPathParam}${params}`)}`.replace(/(\/+)/g,'/');
   }
   omvsSegmentUri(): string {
     return `${this.serverRootUri('omvs')}`;


### PR DESCRIPTION
Fixed case in which the URI broker for unixfile would allow 3 or more slashes in a row
A URL should never have multiple slashes back to back. The uribroker is supposed to prevent this as a source of errors, and did prevent //, but did not prevent /// or //// etc. This would result in software like the apiml rejecting a request from an app.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>