### PR TITLE
Add support for iframes that reference apiml directly

### DIFF
--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -6,29 +6,35 @@
   "dependencies": {
     "@types/core-js": {
       "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha512-F9RHpjuPSit4dCCRXgi7XcqA01DAjy9QY+v9yICoxXsjXD9cgQpyZyL2eSZnTkBGXGaQnea8waZOZTogLDB+rA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-0vMH9wj4l/h10xJQHjtKL9RIHUE=",
       "dev": true
     },
     "@types/jquery": {
-      "version": "3.3.33",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.33.tgz",
-      "integrity": "sha512-U6IdXYGkfUI42SR79vB2Spj+h1Ly3J3UZjpd8mi943lh126TK7CB+HZOxGh2nM3IySor7wqVQdemD/xtydsBKA==",
+      "version": "3.3.38",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/jquery/-/jquery-3.3.38.tgz",
+      "integrity": "sha1-Y4Xx4bML0r/1WujudepCqZnMNgg=",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha1-3M5EMOZLRDuolF8CkPtWStW6xt0=",
+      "dev": true
+    },
     "@types/sizzle": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha1-qBG4wY4rq6t9VCszZYh64uTZ3kc=",
       "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha1-UbHF/mV2o0lTv0slPfnw1JDZ41k=",
       "dev": true,
       "requires": {
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -38,26 +44,26 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha1-G6kmopI2E+3OSW/VsC6M6KX0lyE=",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha1-xJ2tIvZFInxe22EL25aX8aq3Ifc=",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha1-/qk+Qphj3V5DOFVfQikjhaZT8gQ=",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha1-mnQP9I4/qjAisd/1RCPfmqKTwl4=",
       "dev": true,
       "requires": {
         "@webassemblyjs/wast-printer": "1.8.5"
@@ -65,14 +71,14 @@
     },
     "@webassemblyjs/helper-fsm": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha1-ugt9Oz9+RzPaYFnJMyJ12GBwJFI=",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha1-3vS5knsBAdyMu9jR7bW3ucguskU=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -81,14 +87,14 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha1-U3p1Dt31weky83RCBlUckcG5PmE=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha1-dMpqa8vhnlCjtrRihH5pUD5r/L8=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -99,8 +105,8 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha1-cSMp2+8kDza/V70ve4+5v0FUQh4=",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
@@ -108,8 +114,8 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha1-BE7es06mefPgTNT9mCTV41dnrhA=",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
@@ -117,14 +123,14 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha1-qL87XY/+mGx8Hjc8y9wqCRXwztw=",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha1-li2hKqWswcExyBxCMpkcgs5W4Bo=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -139,8 +145,8 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha1-VIQHZsLBAC62TtGr5yCt7XFPmLw=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -152,8 +158,8 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha1-sk2fa6UDlK8TSfUQr6j/y4pj0mQ=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -164,8 +170,8 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha1-IVdvDsiLkUJzV7hTY4NmjvfGa40=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -178,8 +184,8 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha1-4Q7s1ULQ5705T2gnxJ899tTu+4w=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -192,8 +198,8 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha1-EUu8SB/RDKDiOzVg+oEnSLC65bw=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -203,26 +209,26 @@
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
       "dev": true
     },
     "acorn": {
       "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=",
       "dev": true
     },
     "aggregate-error": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha1-2y/nJG5Tb0DZtUQqOeEX191qJOA=",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -230,9 +236,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -243,70 +249,58 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "version": "3.5.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
       "dev": true
     },
     "ansi-colors": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "version": "3.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
       "dev": true,
       "optional": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -314,25 +308,25 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -341,31 +335,39 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -374,13 +376,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -391,14 +393,14 @@
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/async/-/async-2.6.3.tgz",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -406,20 +408,20 @@
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true,
       "optional": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -430,13 +432,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -449,7 +451,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -457,14 +459,14 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/base/-/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
@@ -478,7 +480,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -487,8 +489,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -496,8 +498,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -505,8 +507,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -518,55 +520,45 @@
     },
     "base64-js": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
       "dev": true
     },
     "big.js": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "version": "2.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
       "dev": true,
       "optional": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "version": "5.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-5.1.2.tgz",
+      "integrity": "sha1-yWhpAtPJoncp9DqxD515wgBNp7A=",
       "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -575,8 +567,8 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
         "arr-flatten": "^1.1.0",
@@ -593,7 +585,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -604,14 +596,14 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -624,8 +616,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -635,8 +627,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -647,33 +639,62 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-sign/-/browserify-sign-4.2.0.tgz",
+      "integrity": "sha1-VF0LGwfmssmSEQgr8bEsznoLDhE=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
       }
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -681,8 +702,8 @@
     },
     "buffer": {
       "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -692,32 +713,32 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "cacache": {
       "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-      "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-13.0.1.tgz",
+      "integrity": "sha1-qAAMIWlwiQgvhSh6GuxuOCAkpxw=",
       "dev": true,
       "requires": {
         "chownr": "^1.1.2",
@@ -742,8 +763,8 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
@@ -759,7 +780,7 @@
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -769,14 +790,14 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -785,36 +806,81 @@
       }
     },
     "chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "version": "3.4.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-3.4.1.tgz",
+      "integrity": "sha1-6QW97PEOqgoLHbDGZEgcxMvCK6E=",
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+          "dev": true,
+          "optional": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
       "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -822,8 +888,8 @@
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -832,8 +898,8 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -844,7 +910,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -855,8 +921,8 @@
     },
     "clean-css": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
       "dev": true,
       "requires": {
         "source-map": "~0.6.0"
@@ -864,14 +930,14 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
       "dev": true
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
         "string-width": "^3.1.0",
@@ -881,14 +947,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -898,7 +964,7 @@
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -908,8 +974,8 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -917,32 +983,32 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
       "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
     "compression-webpack-plugin": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-3.1.0.tgz",
-      "integrity": "sha512-iqTHj3rADN4yHwXMBrQa/xrncex/uEQy8QHlaTKxGchT/hC0SdlJlmL/5eRqffmWq2ep0/Romw6Ld39JjTR/ug==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/compression-webpack-plugin/-/compression-webpack-plugin-3.1.0.tgz",
+      "integrity": "sha1-n1EBcqe1+uWq07ZwZS6L15l67so=",
       "dev": true,
       "requires": {
         "cacache": "^13.0.1",
@@ -955,14 +1021,14 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -973,20 +1039,20 @@
     },
     "console-browserify": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
       "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -999,14 +1065,14 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "copy-webpack-plugin": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
+      "integrity": "sha1-VIGgPeoRI9iKmIxv+LeCRyFPC4g=",
       "dev": true,
       "requires": {
         "cacache": "^12.0.3",
@@ -1024,9 +1090,9 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+          "version": "12.0.4",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-12.0.4.tgz",
+          "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -1048,8 +1114,8 @@
         },
         "find-cache-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -1059,8 +1125,8 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -1068,8 +1134,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -1078,8 +1144,8 @@
         },
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -1088,8 +1154,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -1097,14 +1163,14 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -1112,8 +1178,8 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -1123,14 +1189,14 @@
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -1140,30 +1206,38 @@
     },
     "core-js": {
       "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "create-ecdh": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1175,8 +1249,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1189,8 +1263,8 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
@@ -1202,16 +1276,16 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -1229,7 +1303,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -1241,20 +1315,20 @@
     },
     "css-what": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI=",
       "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -1262,20 +1336,20 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
@@ -1283,8 +1357,8 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -1293,8 +1367,8 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -1302,8 +1376,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -1311,8 +1385,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -1324,8 +1398,8 @@
     },
     "des.js": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -1334,31 +1408,39 @@
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "dir-glob": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
       "dev": true,
       "requires": {
         "path-type": "^3.0.0"
@@ -1366,8 +1448,8 @@
     },
     "dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
-      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
       "dev": true,
       "requires": {
         "utila": "~0.4"
@@ -1375,8 +1457,8 @@
     },
     "dom-serializer": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
@@ -1385,28 +1467,28 @@
       "dependencies": {
         "domelementtype": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha1-H4vf6R9aeAYydOgDtL3O326U+U0=",
           "dev": true
         }
       }
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
       "dev": true
     },
     "domhandler": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -1414,7 +1496,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
@@ -1424,8 +1506,8 @@
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -1435,9 +1517,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -1447,33 +1529,41 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "emojis-list": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-      "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+      "version": "4.3.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+      "integrity": "sha1-O4BvO/r8HsfeaVUe+TzKRsFwQSY=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1482,43 +1572,43 @@
       }
     },
     "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+      "version": "2.0.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha1-XEh+V0Krk8Fau12iJ1m4WQ7AO38=",
       "dev": true
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.6",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -1528,14 +1618,14 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1544,14 +1634,14 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
@@ -1559,26 +1649,26 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "version": "3.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/events/-/events-3.2.0.tgz",
+      "integrity": "sha1-k7h8GPjvzUICpGGuxN/AVWtjk3k=",
       "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -1587,7 +1677,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -1602,7 +1692,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -1611,7 +1701,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1622,7 +1712,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -1631,7 +1721,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -1641,8 +1731,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -1652,8 +1742,8 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
         "array-unique": "^0.3.2",
@@ -1668,7 +1758,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -1677,7 +1767,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1686,8 +1776,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -1695,8 +1785,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -1704,8 +1794,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -1716,33 +1806,26 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true
     },
     "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "version": "3.5.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4=",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -1754,7 +1837,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1765,8 +1848,8 @@
     },
     "find-cache-dir": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha1-ibM/rUpGcNqpT4Vff74x1thP6IA=",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -1776,8 +1859,8 @@
     },
     "find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
@@ -1786,8 +1869,8 @@
     },
     "findup-sync": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha1-F7EI+e5RLft6XH88iyfqnhqcCNE=",
       "dev": true,
       "requires": {
         "detect-file": "^1.0.0",
@@ -1798,8 +1881,8 @@
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -1808,13 +1891,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -1823,7 +1906,7 @@
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -1833,8 +1916,8 @@
     },
     "fs-minipass": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -1842,7 +1925,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -1854,590 +1937,39 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+      "version": "2.1.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1",
-        "node-pre-gyp": "*"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.6.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.9.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.3.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.9.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.14.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4.4.2"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "npm-normalize-package-bin": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.13",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2450,7 +1982,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
@@ -2460,7 +1992,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -2471,8 +2003,8 @@
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
       "dev": true,
       "requires": {
         "global-prefix": "^3.0.0"
@@ -2480,8 +2012,8 @@
       "dependencies": {
         "global-prefix": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
           "dev": true,
           "requires": {
             "ini": "^1.3.5",
@@ -2493,7 +2025,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
@@ -2506,7 +2038,7 @@
     },
     "globby": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/globby/-/globby-7.1.1.tgz",
       "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "dev": true,
       "requires": {
@@ -2520,22 +2052,22 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
       "dev": true
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
@@ -2543,7 +2075,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -2552,19 +2084,19 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -2575,7 +2107,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -2585,7 +2117,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -2595,19 +2127,39 @@
       }
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
       }
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2616,13 +2168,13 @@
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/he/-/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -2633,8 +2185,8 @@
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -2642,8 +2194,8 @@
     },
     "html-minifier": {
       "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
-      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
       "dev": true,
       "requires": {
         "camel-case": "3.0.x",
@@ -2657,7 +2209,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -2672,25 +2224,25 @@
       "dependencies": {
         "big.js": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-3.2.0.tgz",
+          "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
           "dev": true
         },
         "emojis-list": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-2.1.0.tgz",
           "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
           "dev": true
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
         "loader-utils": {
           "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
@@ -2704,8 +2256,8 @@
     },
     "htmlparser2": {
       "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
       "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
@@ -2718,14 +2270,14 @@
       "dependencies": {
         "entities": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
           "dev": true
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -2737,32 +2289,32 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
       "dev": true
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
       "dev": true
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "requires": {
         "pkg-dir": "^3.0.0",
@@ -2771,8 +2323,8 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -2780,8 +2332,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -2790,8 +2342,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -2799,14 +2351,14 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -2816,25 +2368,25 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "dev": true
     },
     "infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -2844,25 +2396,25 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "interpret": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
       "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -2871,7 +2423,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -2881,30 +2433,30 @@
       }
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "version": "2.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha1-gzNlYLVKOONeOi33r9BFTWkUaLs=",
       "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -2913,7 +2465,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -2924,14 +2476,14 @@
     },
     "is-date-object": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -2941,34 +2493,34 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -2976,7 +2528,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -2985,7 +2537,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -2996,26 +2548,26 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha1-7OOOOJ5JDfDcIcrqK9WW+Yf3Z/8=",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-symbol": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
@@ -3023,44 +2575,44 @@
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3069,49 +2621,41 @@
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json5": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "kind-of": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true
     },
     "loader-runner": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
       "dev": true
     },
     "loader-utils": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -3121,29 +2665,29 @@
     },
     "locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha1-5I3e2+MLMyF4PFtDAfvTU7weSks=",
       "dev": true
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
@@ -3151,16 +2695,16 @@
       "dependencies": {
         "yallist": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
           "dev": true
         }
       }
     },
     "make-dir": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-      "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+      "version": "3.1.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -3168,19 +2712,19 @@
     },
     "mamacro": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha1-rSyVdhl8nxq/MI0Hh4Zb2XWj8+Q=",
       "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -3189,8 +2733,8 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -3200,8 +2744,8 @@
     },
     "memory-fs": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/memory-fs/-/memory-fs-0.5.0.tgz",
+      "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
       "dev": true,
       "requires": {
         "errno": "^0.1.3",
@@ -3210,8 +2754,8 @@
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -3231,39 +2775,53 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
+    },
     "minipass": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+      "version": "3.1.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha1-fUL/HzljVILhX5zbUxhN7r1YFf0=",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -3271,8 +2829,8 @@
     },
     "minipass-collect": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha1-IrgTv3Rdxu26JXa5QAIq1u3Ixhc=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -3280,17 +2838,17 @@
     },
     "minipass-flush": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha1-gucTXX6JpQ/+ZGEKeHlTxMTLs3M=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
     },
     "minipass-pipeline": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-      "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+      "version": "1.2.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha1-aEcveXEcCEZXwGfFxq2Tzd6oIUw=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -3298,8 +2856,8 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -3316,8 +2874,8 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -3326,8 +2884,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -3337,24 +2895,16 @@
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -3368,21 +2918,14 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -3399,21 +2942,21 @@
       }
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
@@ -3421,8 +2964,8 @@
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
-      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -3452,7 +2995,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -3460,14 +3003,14 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true
     },
     "nth-check": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
       "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
@@ -3475,13 +3018,13 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -3492,7 +3035,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -3501,7 +3044,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -3511,20 +3054,20 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -3533,8 +3076,8 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -3545,8 +3088,8 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -3555,7 +3098,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -3564,7 +3107,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -3573,14 +3116,14 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "version": "2.3.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -3588,8 +3131,8 @@
     },
     "p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
@@ -3597,8 +3140,8 @@
     },
     "p-map": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
@@ -3606,20 +3149,20 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "pako": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
       "dev": true
     },
     "parallel-transform": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
-      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
       "dev": true,
       "requires": {
         "cyclist": "^1.0.1",
@@ -3629,7 +3172,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -3638,8 +3181,8 @@
     },
     "parse-asn1": {
       "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha1-ADJxND2ljclMrOSU+u89IUfs6g4=",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
@@ -3652,56 +3195,56 @@
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
       "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
@@ -3709,16 +3252,16 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "version": "3.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha1-y4cksPramEWWhW0abrr9NYRlS5Q=",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -3730,21 +3273,21 @@
     },
     "picomatch": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
       "dev": true,
       "optional": true
     },
     "pify": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true
     },
     "pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
@@ -3752,13 +3295,13 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "pretty-error": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
@@ -3768,32 +3311,32 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -3802,12 +3345,20 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
       }
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -3816,8 +3367,8 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -3827,8 +3378,8 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -3839,26 +3390,26 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -3866,8 +3417,8 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -3876,8 +3427,8 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -3890,21 +3441,19 @@
       }
     },
     "readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "version": "3.4.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
       "dev": true,
       "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "picomatch": "^2.2.1"
       }
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -3913,21 +3462,21 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true,
       "optional": true
     },
     "renderkid": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
-      "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/renderkid/-/renderkid-2.0.3.tgz",
+      "integrity": "sha1-OAF5wv9a4TZcUivy/Pz/AcW3QUk=",
       "dev": true,
       "requires": {
         "css-select": "^1.1.0",
@@ -3939,32 +3488,32 @@
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.17.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -3972,7 +3521,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -3981,7 +3530,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
@@ -3991,8 +3540,8 @@
       "dependencies": {
         "global-modules": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
           "dev": true,
           "requires": {
             "global-prefix": "^1.0.1",
@@ -4004,26 +3553,26 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "rimraf": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -4031,8 +3580,8 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -4041,7 +3590,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
@@ -4050,26 +3599,26 @@
     },
     "rxjs": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rxjs/-/rxjs-6.2.2.tgz",
+      "integrity": "sha1-63X6PBhv9SiZB9Bkg6d4hFhuHPk=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "rxjs-compat": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.2.2.tgz",
-      "integrity": "sha512-h113JzEXnqBd6JQ8TYg33oDuM3baZ9WKS49rtbMX0gBW2Kz0z4wDZ0/pCA0T9sRJM1HkZT6mt45gpYOJ2MqWYQ=="
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rxjs-compat/-/rxjs-compat-6.2.2.tgz",
+      "integrity": "sha1-PA/NtGEwzHCqVUEsKxFHkFq0aAo="
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -4077,37 +3626,38 @@
       }
     },
     "schema-utils": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-      "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+      "version": "2.7.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-2.7.0.tgz",
+      "integrity": "sha1-FxUfdtjq5n+793lgwzxnatn078c=",
       "dev": true,
       "requires": {
-        "ajv": "^6.12.0",
+        "@types/json-schema": "^7.0.4",
+        "ajv": "^6.12.2",
         "ajv-keywords": "^3.4.1"
       }
     },
     "semver": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
       "dev": true
     },
     "serialize-javascript": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -4118,7 +3668,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4129,14 +3679,14 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -4145,7 +3695,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -4154,20 +3704,20 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
         "base": "^0.11.1",
@@ -4182,7 +3732,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -4191,7 +3741,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4200,7 +3750,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -4208,8 +3758,8 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
         "define-property": "^1.0.0",
@@ -4219,7 +3769,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -4228,8 +3778,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -4237,8 +3787,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -4246,8 +3796,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -4259,8 +3809,8 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
@@ -4268,7 +3818,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4279,20 +3829,20 @@
     },
     "source-list-map": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-loader": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
-      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha1-wYsNxuI79m9nkkN1V8VpoR4HInE=",
       "dev": true,
       "requires": {
         "async": "^2.5.0",
@@ -4301,8 +3851,8 @@
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "dev": true,
       "requires": {
         "atob": "^2.1.2",
@@ -4313,9 +3863,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "version": "0.5.19",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -4324,14 +3874,14 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -4339,14 +3889,14 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "ssri": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ssri/-/ssri-7.1.0.tgz",
+      "integrity": "sha1-ksJBv23oI2W1x/tL126XVSLhKU0=",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1",
@@ -4355,7 +3905,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -4365,7 +3915,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -4376,8 +3926,8 @@
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
       "dev": true,
       "requires": {
         "inherits": "~2.0.1",
@@ -4386,8 +3936,8 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -4396,8 +3946,8 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -4409,14 +3959,14 @@
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
       "dev": true
     },
     "string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
       "dev": true,
       "requires": {
         "emoji-regex": "^7.0.1",
@@ -4426,14 +3976,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -4441,30 +3991,30 @@
         }
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -4472,7 +4022,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -4481,8 +4031,8 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
@@ -4490,20 +4040,20 @@
     },
     "systemjs": {
       "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.21.6.tgz",
-      "integrity": "sha512-R+5S9eV9vcQgWOoS4D87joZ4xkFJHb19ZsyKY07D1+VBDE9bwYcU+KXE0r5XlDA8mFoJGyuWDbfrNoh90JsA8g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/systemjs/-/systemjs-0.21.6.tgz",
+      "integrity": "sha1-nRXnnZ9gq7rCPw0Xn4h+wB8mChs=",
       "dev": true
     },
     "tapable": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
       "dev": true
     },
     "terser": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
-      "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
+      "version": "4.8.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -4513,23 +4063,23 @@
       "dependencies": {
         "commander": {
           "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
           "dev": true
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+      "integrity": "sha1-LGNUQ0cyS6r6mla6rd8WNMir/C8=",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^3.1.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -4537,9 +4087,9 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+          "version": "12.0.4",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-12.0.4.tgz",
+          "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -4561,8 +4111,8 @@
         },
         "find-cache-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -4572,8 +4122,8 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -4581,8 +4131,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -4591,8 +4141,8 @@
         },
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -4601,8 +4151,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -4610,14 +4160,14 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -4625,8 +4175,8 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -4636,14 +4186,23 @@
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
+        },
+        "serialize-javascript": {
+          "version": "3.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -4653,8 +4212,8 @@
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -4663,8 +4222,8 @@
     },
     "timers-browserify": {
       "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -4672,13 +4231,13 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -4687,7 +4246,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4698,8 +4257,8 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
         "define-property": "^2.0.2",
@@ -4710,7 +4269,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -4720,14 +4279,14 @@
     },
     "toposort": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/toposort/-/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
     },
     "ts-loader": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-4.4.2.tgz",
-      "integrity": "sha512-Z3Y1a7A0KZZ1s/mAZkt74l1NAF7Y5xUhD1V9VB8/1eUlUOk8Qa/oo46tO2Uu5kQ3wXypOlbv77lLQySjXEDcdw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ts-loader/-/ts-loader-4.4.2.tgz",
+      "integrity": "sha1-d41EZLJENoc8ePf56RTYgZTCokg=",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -4739,20 +4298,20 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "1.13.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM="
     },
     "tslint": {
       "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tslint/-/tslint-5.10.0.tgz",
       "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
       "dev": true,
       "requires": {
@@ -4772,16 +4331,16 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
     },
     "tsutils": {
       "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -4789,26 +4348,26 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typescript": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha1-HL9h0F1rliaSROtqO85L2RTg8Aw=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
-      "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/uglify-js/-/uglify-js-3.4.10.tgz",
+      "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
       "dev": true,
       "requires": {
         "commander": "~2.19.0",
@@ -4817,16 +4376,16 @@
       "dependencies": {
         "commander": {
           "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
           "dev": true
         }
       }
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -4837,8 +4396,8 @@
     },
     "unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
@@ -4846,8 +4405,8 @@
     },
     "unique-slug": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -4855,7 +4414,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -4865,7 +4424,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -4876,7 +4435,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -4887,7 +4446,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -4895,21 +4454,21 @@
     },
     "upath": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
       "dev": true,
       "optional": true
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -4917,13 +4476,13 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -4933,7 +4492,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -4941,14 +4500,14 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/use/-/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util/-/util-0.11.1.tgz",
+      "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
@@ -4956,7 +4515,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -4964,14 +4523,14 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -4980,165 +4539,136 @@
     },
     "utila": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
       "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha1-VLw83UMxe8qR413K8wWxpyN950U=",
       "dev": true
     },
     "vm-browserify": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
       "dev": true
     },
     "watchpack": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-      "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
+      "version": "1.7.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha1-bp2lOzyAuy1lCBiPWyAEEIZs0ws=",
       "dev": true,
       "requires": {
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
         "watchpack-chokidar2": "^2.0.0"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
-        "binary-extensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-          "dev": true,
-          "optional": true
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-          "dev": true,
-          "optional": true
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true,
-          "optional": true
-        },
-        "readdirp": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "picomatch": "^2.2.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "watchpack-chokidar2": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha1-mUihhmy71suCTeoTp+1pH2yN3/A=",
       "dev": true,
       "optional": true,
       "requires": {
         "chokidar": "^2.1.8"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+          "dev": true,
+          "optional": true
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+          "dev": true,
+          "optional": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        }
       }
     },
     "webpack": {
       "version": "4.41.6",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
-      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha1-EvL4BL9lQu8WZ1UFDUr7yPZrp+E=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -5168,7 +4698,7 @@
       "dependencies": {
         "memory-fs": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/memory-fs/-/memory-fs-0.4.1.tgz",
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "dev": true,
           "requires": {
@@ -5178,8 +4708,8 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -5191,8 +4721,8 @@
     },
     "webpack-cli": {
       "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.12.tgz",
-      "integrity": "sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-cli/-/webpack-cli-3.3.12.tgz",
+      "integrity": "sha1-lOmtoIFFPNCqYJyZ5QABL9OtLUo=",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -5210,8 +4740,8 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -5221,8 +4751,8 @@
     },
     "webpack-log": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
       "dev": true,
       "requires": {
         "ansi-colors": "^3.0.0",
@@ -5231,8 +4761,8 @@
     },
     "webpack-sources": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
       "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",
@@ -5241,8 +4771,8 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -5250,14 +4780,14 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
@@ -5265,8 +4795,8 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -5276,14 +4806,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -5293,32 +4823,32 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
       "dev": true
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "dev": true
     },
     "yargs": {
       "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -5335,8 +4865,8 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -5344,8 +4874,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -5354,8 +4884,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -5363,7 +4893,7 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -5371,8 +4901,8 @@
     },
     "yargs-parser": {
       "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/bootstrap/src/bootstrap/dsm-resources.ts
+++ b/bootstrap/src/bootstrap/dsm-resources.ts
@@ -13,6 +13,7 @@
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 import { DsmUri } from '../uri/dsm-uri'
 import { Dispatcher } from 'zlux-base/dispatcher/dispatcher'
+import { Environment } from 'zlux-base/environment/environment'
 import { Logger } from '../../../../zlux-shared/src/logging/logger'
 import { Registry } from 'zlux-base/registry/registry'
 import { ZoweNotificationManager } from 'zlux-base/notification-manager/notification-manager'
@@ -42,6 +43,7 @@ export class DSMResources {
   static pluginManager = PluginManager
   static uriBroker:ZLUX.UriBroker = new DsmUri();
   static dispatcher:Dispatcher = new Dispatcher(bootstrapLogger);
+  static environment:Environment = new Environment();
   static logger:Logger = logger;
   static registry:ZLUX.Registry = new Registry();
   static notificationManager:ZoweNotificationManager = new ZoweNotificationManager();

--- a/bootstrap/src/bootstrap/rocket-mvd-resources.ts
+++ b/bootstrap/src/bootstrap/rocket-mvd-resources.ts
@@ -13,6 +13,7 @@
 import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 import { MvdUri } from '../uri/mvd-uri'
 import { Dispatcher } from 'zlux-base/dispatcher/dispatcher'
+import { Environment } from 'zlux-base/environment/environment'
 import { Logger } from '../../../../zlux-shared/src/logging/logger'
 import { Registry } from 'zlux-base/registry/registry'
 import { ZoweNotificationManager } from 'zlux-base/notification-manager/notification-manager'
@@ -48,6 +49,7 @@ export class ZoweZLUXResources {
   static pluginManager = PluginManager
   static uriBroker:ZLUX.UriBroker = new MvdUri();
   static dispatcher:Dispatcher = new Dispatcher(bootstrapLogger);
+  static environment:Environment = new Environment();
   static logger:Logger = logger;
   static registry:ZLUX.Registry = new Registry();
   static notificationManager:ZoweNotificationManager = new ZoweNotificationManager();

--- a/bootstrap/src/uri/mvd-uri.ts
+++ b/bootstrap/src/uri/mvd-uri.ts
@@ -16,6 +16,11 @@ const uri_prefix = window.location.pathname.split('ZLUX/plugins/')[0];
 const proxy_mode = (uri_prefix !== '/') ? true : false; // Tells whether we're behind API layer (true) or not (false)
 
 export class MvdUri implements ZLUX.UriBroker {
+
+  usingAPIML(): boolean {
+    return proxy_mode && window.location.pathname.startsWith('/ui/v1/zlux');
+  }
+  
   rasUri(uri: string): string {
     return `${this.serverRootUri(`ras/${uri}`)}`;
   }

--- a/virtual-desktop/package-lock.json
+++ b/virtual-desktop/package-lock.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@angular/animations": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-6.0.9.tgz",
-      "integrity": "sha512-UJTHlxVGZLefCDxTS7T0qZxrAIaQ8gGghHwDI7F3QXpXZTsAk4nHiGSt2EvneW5o6io83i6Hpr/9Fde+YvzWNg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/animations/-/animations-6.0.9.tgz",
+      "integrity": "sha1-wHe411QhF+QjZeFPDwMOqfmn23g=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -15,8 +15,8 @@
     },
     "@angular/cdk": {
       "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-6.3.3.tgz",
-      "integrity": "sha512-cfUwvnGGByZy/poA75/vsELBq68eDUYJe3qi0WvSbtFzbQlsxeqaBiaxVYqmHJkPlSF5nsUhg5KvDowED3a4sA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/cdk/-/cdk-6.3.3.tgz",
+      "integrity": "sha1-IvsNMDzmF2QnukyZJ1byWMO1o4g=",
       "dev": true,
       "requires": {
         "tslib": "^1.7.1"
@@ -24,8 +24,8 @@
     },
     "@angular/common": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-6.0.9.tgz",
-      "integrity": "sha512-zjJ9WDW9787sTRiNeUvQaCvGZJu1dI8A3fYtSL8BKrGhxLsf24cSa3ljbrSmtIsCGImNxTToHzPFXo4sx2dvYg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/common/-/common-6.0.9.tgz",
+      "integrity": "sha1-4S/E6nTNufAHrxCY01c8jVRBaAo=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -33,8 +33,8 @@
     },
     "@angular/compiler": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-6.0.9.tgz",
-      "integrity": "sha512-/A6U/W0settfkh3tmX9p3t7+OyZ0c2sIJMlQjhfF36do0ylnIl4wuqJtHF0BWr/wmmbQzg+qAsQyWrx8vp+2Iw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/compiler/-/compiler-6.0.9.tgz",
+      "integrity": "sha1-fU+7CPiMvvfP944RqUdOjfVRa+4=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -42,8 +42,8 @@
     },
     "@angular/compiler-cli": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-6.0.9.tgz",
-      "integrity": "sha512-v3C5RyJLKoDcQocDt/U195t9v8UpBH+mwVaBkEM+nLkZAGC1Uvg9nPuUXisOwljuMm9VtOWG3A8hKQ5ZYieNBg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/compiler-cli/-/compiler-cli-6.0.9.tgz",
+      "integrity": "sha1-pLSLN9iz3Y1wLgNNTwYlltBIqKI=",
       "dev": true,
       "requires": {
         "chokidar": "^1.4.2",
@@ -54,8 +54,8 @@
     },
     "@angular/core": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-6.0.9.tgz",
-      "integrity": "sha512-NeEUgymsR/tLvWeEAA4mGEX/S4hHbIo/2uwPGGAQAvzlk+pL7xqPoFSMKeqQahdTnWSmYa/2+X33OdJgXKKXyg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/core/-/core-6.0.9.tgz",
+      "integrity": "sha1-pozA9d3/pTXfZfPnmLovzW9u7Bs=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -63,8 +63,8 @@
     },
     "@angular/forms": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-6.0.9.tgz",
-      "integrity": "sha512-hZxzoO/QAd9EetNUdGpb5Wiw4Lb7R+iOCjdV8sh+C8q6Ow5G35/dfiAlNanGXVqSi8e6Qqm1aO/r4cTUWFm6vw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/forms/-/forms-6.0.9.tgz",
+      "integrity": "sha1-QlJiaHUxnwngPWteth6o0nQGG48=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -72,8 +72,8 @@
     },
     "@angular/http": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-6.0.9.tgz",
-      "integrity": "sha512-JaYvBQQ+hJ7SKqZ+zw4C20lc7b6U5kK50nSkams10tzhITke6L/+wK8g3kiNu4XcqE5nqcIN8S95UkMGPMsa7Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/http/-/http-6.0.9.tgz",
+      "integrity": "sha1-GZwEzACFu+ukS5gyugKYSMN21ak=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -81,8 +81,8 @@
     },
     "@angular/material": {
       "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-6.3.3.tgz",
-      "integrity": "sha512-3qTZ8+pjc8P1D+TLr9ETGfFyMYO+BAQlFiVs3oV8rw5y0Wzkz6G1JHfKQ2oOd8/npXP6rJQldssUM4IBbSOxIQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/material/-/material-6.3.3.tgz",
+      "integrity": "sha1-T3RAK6bkuAzwQm5iwSQCROaXQGk=",
       "dev": true,
       "requires": {
         "parse5": "^5.0.0",
@@ -91,8 +91,8 @@
     },
     "@angular/platform-browser": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-6.0.9.tgz",
-      "integrity": "sha512-q/1UGlbWBwZ6c63p8SDmBsgjYgMQUxyByY9GGt0hd5XhOfVFzvBSzybKSRc3FBhmxQJMCtVhEbI0kIzqrDxcWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/platform-browser/-/platform-browser-6.0.9.tgz",
+      "integrity": "sha1-P2c4BG7KA//91FWKs8p1ZztvEdE=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -100,8 +100,8 @@
     },
     "@angular/platform-browser-dynamic": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-6.0.9.tgz",
-      "integrity": "sha512-HsmLafy0hpMIZlwHz1XRicXczZWCKb0H6oCY+TepFV4u3SLZgJEO7/HZrhO0kEviipXuXrgZSpafV3IYP6eWPQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/platform-browser-dynamic/-/platform-browser-dynamic-6.0.9.tgz",
+      "integrity": "sha1-I3//copRjMj7iQlGOP8yxA0xA3Q=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -109,8 +109,8 @@
     },
     "@angular/router": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-6.0.9.tgz",
-      "integrity": "sha512-kS489FFpGWD4GEDDozfVb+eD5qf1E9cLYgsE7RO914uNMh/sJuRZt9PVu0bcX12fOOO7mTcOiWtlkefzUAJbkA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@angular/router/-/router-6.0.9.tgz",
+      "integrity": "sha1-xAVyAxx/8uHftSeajLUIuWKoUmI=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -118,38 +118,44 @@
     },
     "@types/html2canvas": {
       "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@types/html2canvas/-/html2canvas-0.0.35.tgz",
-      "integrity": "sha512-28p0/yNwXnvGWQK3rEIBj7NHNQoBXuX0ymcCNjSYR/i0Vk9z+xrKCQZPvsrEmurx9vs4B/eHGbOaJY/a9CXdSg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/html2canvas/-/html2canvas-0.0.35.tgz",
+      "integrity": "sha1-oAloGjIHp6gwLmXeA0/41CyUnPc=",
       "dev": true,
       "requires": {
         "@types/jquery": "*"
       }
     },
     "@types/jquery": {
-      "version": "3.3.38",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.38.tgz",
-      "integrity": "sha512-nkDvmx7x/6kDM5guu/YpXkGZ/Xj/IwGiLDdKM99YA5Vag7pjGyTJ8BNUh/6hxEn/sEu5DKtyRgnONJ7EmOoKrA==",
+      "version": "3.5.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha1-zrsFes9QccQOQ58w6EDFejDUBsM=",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha1-3M5EMOZLRDuolF8CkPtWStW6xt0=",
+      "dev": true
+    },
     "@types/sizzle": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha1-qBG4wY4rq6t9VCszZYh64uTZ3kc=",
       "dev": true
     },
     "@types/xmldom": {
       "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.29.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/xmldom/-/xmldom-0.1.29.tgz",
       "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E=",
       "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha1-UbHF/mV2o0lTv0slPfnw1JDZ41k=",
       "dev": true,
       "requires": {
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -159,26 +165,26 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha1-G6kmopI2E+3OSW/VsC6M6KX0lyE=",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha1-xJ2tIvZFInxe22EL25aX8aq3Ifc=",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha1-/qk+Qphj3V5DOFVfQikjhaZT8gQ=",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha1-mnQP9I4/qjAisd/1RCPfmqKTwl4=",
       "dev": true,
       "requires": {
         "@webassemblyjs/wast-printer": "1.8.5"
@@ -186,14 +192,14 @@
     },
     "@webassemblyjs/helper-fsm": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha1-ugt9Oz9+RzPaYFnJMyJ12GBwJFI=",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha1-3vS5knsBAdyMu9jR7bW3ucguskU=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -202,14 +208,14 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha1-U3p1Dt31weky83RCBlUckcG5PmE=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha1-dMpqa8vhnlCjtrRihH5pUD5r/L8=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -220,8 +226,8 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha1-cSMp2+8kDza/V70ve4+5v0FUQh4=",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
@@ -229,8 +235,8 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha1-BE7es06mefPgTNT9mCTV41dnrhA=",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
@@ -238,14 +244,14 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha1-qL87XY/+mGx8Hjc8y9wqCRXwztw=",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha1-li2hKqWswcExyBxCMpkcgs5W4Bo=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -260,8 +266,8 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha1-VIQHZsLBAC62TtGr5yCt7XFPmLw=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -273,8 +279,8 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha1-sk2fa6UDlK8TSfUQr6j/y4pj0mQ=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -285,8 +291,8 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha1-IVdvDsiLkUJzV7hTY4NmjvfGa40=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -299,8 +305,8 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha1-4Q7s1ULQ5705T2gnxJ899tTu+4w=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -313,8 +319,8 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha1-EUu8SB/RDKDiOzVg+oEnSLC65bw=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -324,18 +330,18 @@
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
       "dev": true
     },
     "@zlux/widgets": {
-      "version": "git+https://github.com/zowe/zlux-widgets.git#1cd6ede810ca0bc4ae35df8043eaef1987833e95",
+      "version": "git+https://github.com/zowe/zlux-widgets.git#1d3e59cbc5c7b8f4fb118a15acbefbde475a0428",
       "from": "git+https://github.com/zowe/zlux-widgets.git",
       "dev": true,
       "requires": {
@@ -352,14 +358,14 @@
     },
     "acorn": {
       "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=",
       "dev": true
     },
     "aggregate-error": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha1-2y/nJG5Tb0DZtUQqOeEX191qJOA=",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -367,9 +373,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "version": "6.12.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -380,20 +386,20 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "version": "3.5.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
       "dev": true
     },
     "angular-l10n": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/angular-l10n/-/angular-l10n-5.2.0.tgz",
-      "integrity": "sha512-/dv3WgjkecrzAt5lyOheoamHCeYuiXUir7soq5YWILIV1G7YlGCOx5yPOSjV8XQ7QUnnR3QgAv+SxxvbQMXsZg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/angular-l10n/-/angular-l10n-5.2.0.tgz",
+      "integrity": "sha1-WA3Ya8GZQ1SSYxaeaiNTMVUJ9o0=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -401,7 +407,7 @@
     },
     "angular2-template-loader": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/angular2-template-loader/-/angular2-template-loader-0.6.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/angular2-template-loader/-/angular2-template-loader-0.6.2.tgz",
       "integrity": "sha1-wNROkP/w+sleiyPwQ6zaf9HFHXw=",
       "dev": true,
       "requires": {
@@ -410,26 +416,26 @@
     },
     "ansi-colors": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "^2.1.5",
@@ -438,20 +444,20 @@
     },
     "app-root-path": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
-      "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/app-root-path/-/app-root-path-2.2.1.tgz",
+      "integrity": "sha1-0N9KaC7kCCc1g9Q/b3npiSYkvJo=",
       "dev": true
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -459,7 +465,7 @@
       "dependencies": {
         "sprintf-js": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
           "dev": true
         }
@@ -467,7 +473,7 @@
     },
     "aria-query": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/aria-query/-/aria-query-3.0.0.tgz",
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "dev": true,
       "requires": {
@@ -477,7 +483,7 @@
     },
     "arr-diff": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
@@ -486,19 +492,19 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -507,20 +513,20 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -528,8 +534,8 @@
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -538,17 +544,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -557,13 +563,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -574,26 +580,26 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/async/-/async-2.6.3.tgz",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -601,43 +607,43 @@
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "version": "1.10.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI=",
       "dev": true
     },
     "axobject-query": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
-      "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
+      "version": "2.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/axobject-query/-/axobject-query-2.2.0.tgz",
+      "integrity": "sha1-lD1H4QwLcEqkInXiDt83ImSJib4=",
       "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -648,14 +654,14 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/base/-/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
@@ -669,7 +675,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -678,8 +684,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -687,8 +693,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -696,8 +702,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -707,33 +713,33 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         }
       }
     },
     "base64-arraybuffer": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha1-S5RPrAGRqlkHr+LYyZnMxXzoD0U=",
       "dev": true
     },
     "base64-js": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -742,20 +748,20 @@
     },
     "big.js": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
       "dev": true
     },
     "binary-extensions": {
       "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
       "dev": true
     },
     "bindings": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -764,26 +770,26 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true
     },
     "bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+      "version": "5.1.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-5.1.2.tgz",
+      "integrity": "sha1-yWhpAtPJoncp9DqxD515wgBNp7A=",
       "dev": true
     },
     "bootstrap": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha1-KAyo9hBQTZnXtrS/xLaM7GAXBKw=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -792,7 +798,7 @@
     },
     "braces": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
@@ -803,14 +809,14 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -823,8 +829,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -834,8 +840,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -846,7 +852,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -855,17 +861,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "browserify-sign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
-      "integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
+      "version": "4.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-sign/-/browserify-sign-4.2.0.tgz",
+      "integrity": "sha1-VF0LGwfmssmSEQgr8bEsznoLDhE=",
       "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
@@ -875,26 +881,33 @@
         "elliptic": "^6.5.2",
         "inherits": "^2.0.4",
         "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0"
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
         }
       }
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -902,8 +915,8 @@
     },
     "buffer": {
       "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -913,32 +926,32 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "cacache": {
       "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-      "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-13.0.1.tgz",
+      "integrity": "sha1-qAAMIWlwiQgvhSh6GuxuOCAkpxw=",
       "dev": true,
       "requires": {
         "chownr": "^1.1.2",
@@ -963,8 +976,8 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
@@ -980,7 +993,7 @@
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -988,19 +1001,19 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -1013,7 +1026,7 @@
     },
     "chokidar": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
@@ -1030,14 +1043,14 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
       "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -1045,8 +1058,8 @@
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -1055,8 +1068,8 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -1067,7 +1080,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -1076,7 +1089,7 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -1084,14 +1097,14 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
       "dev": true
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
         "string-width": "^3.1.0",
@@ -1101,14 +1114,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -1118,8 +1131,8 @@
     },
     "codelyzer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-5.1.2.tgz",
-      "integrity": "sha512-1z7mtpwxcz5uUqq0HLO0ifj/tz2dWEmeaK+8c5TEZXAwwVxrjjg0118ODCOCCOcpfYaaEHxStNCaWVYo9FUPXw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/codelyzer/-/codelyzer-5.1.2.tgz",
+      "integrity": "sha1-5sCCafh5ZIPlfm2bfClyNXJHKx0=",
       "dev": true,
       "requires": {
         "app-root-path": "^2.2.1",
@@ -1135,7 +1148,7 @@
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -1145,8 +1158,8 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -1154,14 +1167,14 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -1169,26 +1182,26 @@
     },
     "commander": {
       "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
     "compression-webpack-plugin": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-3.1.0.tgz",
-      "integrity": "sha512-iqTHj3rADN4yHwXMBrQa/xrncex/uEQy8QHlaTKxGchT/hC0SdlJlmL/5eRqffmWq2ep0/Romw6Ld39JjTR/ug==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/compression-webpack-plugin/-/compression-webpack-plugin-3.1.0.tgz",
+      "integrity": "sha1-n1EBcqe1+uWq07ZwZS6L15l67so=",
       "dev": true,
       "requires": {
         "cacache": "^13.0.1",
@@ -1201,14 +1214,14 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -1219,20 +1232,20 @@
     },
     "console-browserify": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
       "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -1245,14 +1258,14 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "copy-webpack-plugin": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
+      "integrity": "sha1-VIGgPeoRI9iKmIxv+LeCRyFPC4g=",
       "dev": true,
       "requires": {
         "cacache": "^12.0.3",
@@ -1271,14 +1284,14 @@
       "dependencies": {
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "cacache": {
           "version": "12.0.4",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-          "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-12.0.4.tgz",
+          "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -1300,14 +1313,14 @@
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "find-cache-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -1317,8 +1330,8 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -1326,7 +1339,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -1336,7 +1349,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -1347,14 +1360,14 @@
         },
         "is-extglob": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -1362,8 +1375,8 @@
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -1371,8 +1384,8 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -1382,8 +1395,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -1392,8 +1405,8 @@
         },
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -1402,14 +1415,14 @@
         },
         "normalize-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
           "dev": true
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -1417,14 +1430,14 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -1432,8 +1445,8 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -1443,8 +1456,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -1454,20 +1467,20 @@
     },
     "core-js": {
       "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "create-ecdh": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -1475,17 +1488,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1497,8 +1510,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1511,8 +1524,8 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
@@ -1524,8 +1537,8 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -1543,8 +1556,8 @@
     },
     "css-line-break": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.1.1.tgz",
-      "integrity": "sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/css-line-break/-/css-line-break-1.1.1.tgz",
+      "integrity": "sha1-1em90peEAJnrBQPHMQ/TSSegJu8=",
       "dev": true,
       "requires": {
         "base64-arraybuffer": "^0.2.0"
@@ -1552,8 +1565,8 @@
     },
     "css-loader": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
-      "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/css-loader/-/css-loader-1.0.1.tgz",
+      "integrity": "sha1-aIW7UjOzXsR7AGBX2gHMZAtref4=",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -1572,20 +1585,20 @@
       "dependencies": {
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -1593,8 +1606,8 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -1605,19 +1618,18 @@
       }
     },
     "css-selector-tokenizer": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.2.tgz",
-      "integrity": "sha512-yj856NGuAymN6r8bn8/Jl46pR+OC3eEvAhfGYDUe7YPtTPAYrSSw4oAniZ9Y8T5B92hjhwTBLUen0/vKPxf6pw==",
+      "version": "0.7.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+      "integrity": "sha1-c18mGG5nx0mq8nV4NAXPBmH66PE=",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2",
-        "regexpu-core": "^4.6.0"
+        "fastparse": "^1.1.2"
       }
     },
     "cssauron": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cssauron/-/cssauron-1.4.0.tgz",
       "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
       "dev": true,
       "requires": {
@@ -1626,25 +1638,25 @@
     },
     "cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
       "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
-      "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
+      "integrity": "sha1-FDwWQcs9hcYMMjKeJoma3qhwF5E=",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -1653,8 +1665,8 @@
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -1662,20 +1674,20 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -1684,8 +1696,8 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -1693,8 +1705,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -1702,8 +1714,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -1713,28 +1725,28 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         }
       }
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "des.js": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -1743,20 +1755,20 @@
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -1765,17 +1777,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "dir-glob": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
       "dev": true,
       "requires": {
         "path-type": "^3.0.0"
@@ -1783,14 +1795,14 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -1801,7 +1813,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -1810,9 +1822,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -1825,38 +1837,38 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-      "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+      "version": "4.3.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+      "integrity": "sha1-O4BvO/r8HsfeaVUe+TzKRsFwQSY=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1866,8 +1878,8 @@
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "dev": true,
       "requires": {
         "prr": "~1.0.1"
@@ -1875,14 +1887,14 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1891,14 +1903,14 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
@@ -1906,50 +1918,35 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "version": "3.2.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/events/-/events-3.2.0.tgz",
+      "integrity": "sha1-k7h8GPjvzUICpGGuxN/AVWtjk3k=",
       "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
     },
-    "execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
     "expand-brackets": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
@@ -1958,7 +1955,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -1967,7 +1964,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -1976,8 +1973,8 @@
     },
     "exports-loader": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.7.0.tgz",
-      "integrity": "sha512-RKwCrO4A6IiKm0pG3c9V46JxIHcDplwwGJn6+JJ1RcVnh/WSGJa0xkmk5cRVtgOPzCAtTMGj2F7nluh9L0vpSA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/exports-loader/-/exports-loader-0.7.0.tgz",
+      "integrity": "sha1-hIgceE3qYDa44c0drD2ptkCeIaU=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
@@ -1986,20 +1983,20 @@
       "dependencies": {
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -2007,8 +2004,8 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -2018,7 +2015,7 @@
         },
         "source-map": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.5.0.tgz",
           "integrity": "sha1-D+llA6yGpa213mP05BKuSHLNvoY=",
           "dev": true
         }
@@ -2026,13 +2023,13 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -2042,8 +2039,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -2053,7 +2050,7 @@
     },
     "extglob": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
@@ -2062,38 +2059,38 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true
     },
     "fastparse": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha1-kXKMWllC7O2FMSg8eUQe5BIsNak=",
       "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4=",
       "dev": true
     },
     "file-loader": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
-      "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/file-loader/-/file-loader-1.1.11.tgz",
+      "integrity": "sha1-b+iGRJsPKpNuQ8q6rAzb+zaVBvg=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.0.2",
@@ -2102,20 +2099,20 @@
       "dependencies": {
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -2123,8 +2120,8 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -2134,8 +2131,8 @@
         },
         "schema-utils": {
           "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha1-unT1l9K+LqiAExdG7hfQoJPGgYc=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -2146,21 +2143,21 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "dev": true,
       "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
       "dev": true,
       "requires": {
         "is-number": "^2.1.0",
@@ -2172,8 +2169,8 @@
     },
     "find-cache-dir": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha1-ibM/rUpGcNqpT4Vff74x1thP6IA=",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -2183,8 +2180,8 @@
     },
     "find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
@@ -2193,8 +2190,8 @@
     },
     "findup-sync": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha1-F7EI+e5RLft6XH88iyfqnhqcCNE=",
       "dev": true,
       "requires": {
         "detect-file": "^1.0.0",
@@ -2205,20 +2202,20 @@
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -2235,7 +2232,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -2246,7 +2243,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
@@ -2261,7 +2258,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -2270,7 +2267,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -2279,7 +2276,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -2288,7 +2285,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -2299,7 +2296,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -2308,7 +2305,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -2319,8 +2316,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
@@ -2330,16 +2327,16 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -2354,7 +2351,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -2363,7 +2360,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -2374,7 +2371,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -2386,7 +2383,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -2397,8 +2394,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -2406,8 +2403,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -2415,8 +2412,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -2426,14 +2423,14 @@
         },
         "is-extglob": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -2441,7 +2438,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -2450,7 +2447,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -2461,20 +2458,20 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -2496,8 +2493,8 @@
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2506,19 +2503,19 @@
     },
     "font-awesome": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/font-awesome/-/font-awesome-4.7.0.tgz",
       "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
       "dev": true
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
@@ -2527,14 +2524,14 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -2544,7 +2541,7 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -2553,7 +2550,7 @@
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -2563,8 +2560,8 @@
     },
     "fs-minipass": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -2572,7 +2569,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -2584,14 +2581,14 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
       "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2601,28 +2598,19 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
-    },
-    "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      }
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -2631,8 +2619,8 @@
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2645,7 +2633,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -2655,7 +2643,7 @@
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
@@ -2664,8 +2652,8 @@
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
       "dev": true,
       "requires": {
         "global-prefix": "^3.0.0"
@@ -2673,8 +2661,8 @@
       "dependencies": {
         "global-prefix": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
           "dev": true,
           "requires": {
             "ini": "^1.3.5",
@@ -2684,15 +2672,15 @@
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         }
       }
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
@@ -2705,7 +2693,7 @@
     },
     "globby": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/globby/-/globby-7.1.1.tgz",
       "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "dev": true,
       "requires": {
@@ -2719,7 +2707,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -2727,29 +2715,29 @@
     },
     "graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -2758,13 +2746,13 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -2775,7 +2763,7 @@
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -2783,7 +2771,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -2793,7 +2781,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -2802,7 +2790,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -2813,7 +2801,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -2824,8 +2812,8 @@
     },
     "hash-base": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.4",
@@ -2835,8 +2823,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -2846,16 +2834,16 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
           "dev": true
         }
       }
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2864,13 +2852,13 @@
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/he/-/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -2881,8 +2869,8 @@
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -2890,8 +2878,8 @@
     },
     "html2canvas": {
       "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.5.tgz",
-      "integrity": "sha512-DtNqPxJNXPoTajs+lVQzGS1SULRI4GQaROeU5R41xH8acffHukxRh/NBVcTBsfCkJSkLq91rih5TpbEwUP9yWA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/html2canvas/-/html2canvas-1.0.0-rc.5.tgz",
+      "integrity": "sha1-TuPKyfbiCg+gwvNab5nJYK5+xME=",
       "dev": true,
       "requires": {
         "css-line-break": "1.1.1"
@@ -2899,7 +2887,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -2910,19 +2898,19 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
       "dev": true
     },
     "icss-utils": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
@@ -2931,26 +2919,26 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
       "dev": true
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
       "dev": true
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "requires": {
         "pkg-dir": "^3.0.0",
@@ -2959,8 +2947,8 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -2968,8 +2956,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -2978,8 +2966,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -2987,14 +2975,14 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -3004,25 +2992,25 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "dev": true
     },
     "infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -3032,31 +3020,25 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-      "dev": true
-    },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "version": "1.4.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
       "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -3065,7 +3047,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -3074,13 +3056,13 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -3089,8 +3071,8 @@
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -3100,21 +3082,21 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -3123,25 +3105,25 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
@@ -3150,7 +3132,7 @@
     },
     "is-number": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
@@ -3159,8 +3141,8 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -3168,7 +3150,7 @@
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -3176,55 +3158,49 @@
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "requires": {
@@ -3233,26 +3209,26 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
+      "version": "3.5.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha1-17TQjhv9uGrS8aPQOeoXMEcXq7U=",
       "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3261,55 +3237,49 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
     "json-loader": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -3321,31 +3291,22 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
     },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
-    },
     "loader-runner": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
       "dev": true
     },
     "loader-utils": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
@@ -3357,23 +3318,23 @@
     },
     "locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha1-5I3e2+MLMyF4PFtDAfvTU7weSks=",
       "dev": true
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
@@ -3381,16 +3342,16 @@
       "dependencies": {
         "yallist": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
           "dev": true
         }
       }
     },
     "make-dir": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -3398,36 +3359,27 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
       }
     },
     "mamacro": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha1-rSyVdhl8nxq/MI0Hh4Zb2XWj8+Q=",
       "dev": true
-    },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -3436,14 +3388,14 @@
     },
     "math-random": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw=",
       "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -3451,21 +3403,10 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      }
-    },
     "memory-fs": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/memory-fs/-/memory-fs-0.5.0.tgz",
+      "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
       "dev": true,
       "requires": {
         "errno": "^0.1.3",
@@ -3474,7 +3415,7 @@
     },
     "micromatch": {
       "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
@@ -3495,8 +3436,8 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -3504,56 +3445,50 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "mime": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
-      "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+      "version": "2.4.6",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
       "dev": true
     },
     "mime-db": {
       "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
       "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
     },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -3561,14 +3496,14 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "minipass": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha1-fUL/HzljVILhX5zbUxhN7r1YFf0=",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -3576,8 +3511,8 @@
     },
     "minipass-collect": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha1-IrgTv3Rdxu26JXa5QAIq1u3Ixhc=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -3585,17 +3520,17 @@
     },
     "minipass-flush": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha1-gucTXX6JpQ/+ZGEKeHlTxMTLs3M=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
     },
     "minipass-pipeline": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.3.tgz",
-      "integrity": "sha512-cFOknTvng5vqnwOpDsZTWhNll6Jf8o2x+/diplafmxpuIymAjzoOolZG0VvQf3V2HgqzJNhnuKHYp2BqDgz8IQ==",
+      "version": "1.2.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha1-aEcveXEcCEZXwGfFxq2Tzd6oIUw=",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -3603,8 +3538,8 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -3621,8 +3556,8 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -3631,8 +3566,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -3642,8 +3577,8 @@
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
@@ -3651,13 +3586,13 @@
     },
     "moment": {
       "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
-      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/moment/-/moment-2.25.3.tgz",
+      "integrity": "sha1-JS/0ExnPQeR3YaGojKsw7f6YCMA=",
       "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -3671,21 +3606,21 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "nan": {
       "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha1-174036MQW5FJTDFHCJMV7/iHSwE=",
       "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -3703,34 +3638,34 @@
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         }
       }
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "ngx-file-drop": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ngx-file-drop/-/ngx-file-drop-6.0.1.tgz",
-      "integrity": "sha512-+9VC/JgBwaonoiUFdd3lROvZsVtPnoTvvm1oK5bITOuqff4lE7wfUhbdm+0ZyO14aa7hwgGHuT2MBPQq4369oA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ngx-file-drop/-/ngx-file-drop-6.0.1.tgz",
+      "integrity": "sha1-Y3uG6MaiqoD6oomeo9tATsIUrlo=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -3738,8 +3673,8 @@
     },
     "ngx-i18nsupport": {
       "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/ngx-i18nsupport/-/ngx-i18nsupport-0.17.1.tgz",
-      "integrity": "sha512-d8OCQs/XYBEI9qvztQyEkd8gEPFEBmyRg8UcriGQV8Ew1ujvrIieHxmX8YpDpFZKQ4ePextQGUSvjpGd2NauEQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ngx-i18nsupport/-/ngx-i18nsupport-0.17.1.tgz",
+      "integrity": "sha1-3/O5ieUTsU3/mQl+2Yd4wS5Ig/w=",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -3752,8 +3687,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -3761,8 +3696,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -3772,8 +3707,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -3783,8 +3718,8 @@
     },
     "ngx-i18nsupport-lib": {
       "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/ngx-i18nsupport-lib/-/ngx-i18nsupport-lib-1.10.2.tgz",
-      "integrity": "sha512-Z81I2/HUtZ/7X7C3sioJj/Zr/M0iQs0aR5EhYsrWTzdEy7fZWFVYabzzZs+8h6lhQ/4yIl+3sVOCBkI9BiUUEQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ngx-i18nsupport-lib/-/ngx-i18nsupport-lib-1.10.2.tgz",
+      "integrity": "sha1-qJDp8a1kVBlkDbsSbowNMmaFqec=",
       "dev": true,
       "requires": {
         "@types/xmldom": "^0.1.29",
@@ -3794,14 +3729,14 @@
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
-      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -3831,7 +3766,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -3839,37 +3774,28 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
     },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -3880,7 +3806,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -3891,7 +3817,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -3900,7 +3826,7 @@
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -3908,7 +3834,7 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
@@ -3918,7 +3844,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -3927,7 +3853,7 @@
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -3935,7 +3861,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -3944,43 +3870,14 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-      "dev": true
-    },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -3988,8 +3885,8 @@
     },
     "p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
@@ -3997,8 +3894,8 @@
     },
     "p-map": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
@@ -4006,20 +3903,20 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "pako": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
       "dev": true
     },
     "parallel-transform": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
-      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
       "dev": true,
       "requires": {
         "cyclist": "^1.0.1",
@@ -4029,8 +3926,8 @@
     },
     "parse-asn1": {
       "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha1-ADJxND2ljclMrOSU+u89IUfs6g4=",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
@@ -4043,7 +3940,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -4055,63 +3952,63 @@
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "parse5": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha1-9o5OW6GFKsLK3AD0VV//bCq7YXg=",
       "dev": true,
       "optional": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
       "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
@@ -4119,16 +4016,16 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "version": "3.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha1-y4cksPramEWWhW0abrr9NYRlS5Q=",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -4140,20 +4037,27 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
+      "dev": true,
+      "optional": true
+    },
     "pify": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true
     },
     "pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
@@ -4161,20 +4065,20 @@
     },
     "popper.js": {
       "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
-      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha1-4x7AbPrGqXpTKAw+VeTgyGDnc44=",
       "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "postcss": {
       "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss/-/postcss-6.0.23.tgz",
+      "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
@@ -4184,8 +4088,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -4193,8 +4097,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -4204,14 +4108,14 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -4221,8 +4125,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
-      "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+      "integrity": "sha1-3IfjQUjsfqtfeR981YSYMzdbdBo=",
       "dev": true,
       "requires": {
         "postcss": "^6.0.1"
@@ -4230,7 +4134,7 @@
     },
     "postcss-modules-local-by-default": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
@@ -4240,7 +4144,7 @@
     },
     "postcss-modules-scope": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
@@ -4250,7 +4154,7 @@
     },
     "postcss-modules-values": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
@@ -4260,50 +4164,50 @@
     },
     "postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
       "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -4315,17 +4219,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -4334,8 +4238,8 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -4345,8 +4249,8 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -4357,32 +4261,32 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randomatic": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
       "dev": true,
       "requires": {
         "is-number": "^4.0.0",
@@ -4392,22 +4296,22 @@
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         }
       }
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -4415,8 +4319,8 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -4425,14 +4329,14 @@
     },
     "raw-loader": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/raw-loader/-/raw-loader-0.5.1.tgz",
       "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
       "dev": true
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -4446,8 +4350,8 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -4457,20 +4361,20 @@
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -4487,7 +4391,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -4498,7 +4402,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
@@ -4513,7 +4417,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -4522,7 +4426,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -4531,7 +4435,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -4540,7 +4444,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -4551,7 +4455,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -4560,7 +4464,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -4571,8 +4475,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
@@ -4582,16 +4486,16 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -4606,7 +4510,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -4615,7 +4519,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -4626,7 +4530,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -4638,7 +4542,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -4649,8 +4553,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -4658,8 +4562,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -4667,8 +4571,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -4678,7 +4582,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -4687,7 +4591,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -4698,20 +4602,20 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -4733,29 +4637,14 @@
     },
     "reflect-metadata": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha1-Z648pXyXKiqhZCsQ/jY/4y1J3Ag=",
       "dev": true
-    },
-    "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
-    },
-    "regenerate-unicode-properties": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.4.0"
-      }
     },
     "regex-cache": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
@@ -4763,65 +4652,36 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
     },
-    "regexpu-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.2.0",
-        "regjsgen": "^0.5.1",
-        "regjsparser": "^0.6.4",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.2.0"
-      }
-    },
-    "regjsgen": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-      "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      }
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/request/-/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -4848,26 +4708,26 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "requirejs": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha1-5Qk9lgHCgpJRJYwLlEXU0Z+p58k=",
       "dev": true
     },
     "resolve": {
       "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -4875,7 +4735,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -4884,7 +4744,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
@@ -4894,8 +4754,8 @@
       "dependencies": {
         "global-modules": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
           "dev": true,
           "requires": {
             "global-prefix": "^1.0.1",
@@ -4907,26 +4767,26 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "rimraf": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -4934,8 +4794,8 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -4944,7 +4804,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
@@ -4953,8 +4813,8 @@
     },
     "rxjs": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rxjs/-/rxjs-6.2.2.tgz",
+      "integrity": "sha1-63X6PBhv9SiZB9Bkg6d4hFhuHPk=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -4962,19 +4822,19 @@
     },
     "rxjs-compat": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.2.2.tgz",
-      "integrity": "sha512-h113JzEXnqBd6JQ8TYg33oDuM3baZ9WKS49rtbMX0gBW2Kz0z4wDZ0/pCA0T9sRJM1HkZT6mt45gpYOJ2MqWYQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/rxjs-compat/-/rxjs-compat-6.2.2.tgz",
+      "integrity": "sha1-PA/NtGEwzHCqVUEsKxFHkFq0aAo=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -4983,24 +4843,25 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "schema-utils": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
-      "integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
+      "version": "2.7.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-2.7.0.tgz",
+      "integrity": "sha1-FxUfdtjq5n+793lgwzxnatn078c=",
       "dev": true,
       "requires": {
-        "ajv": "^6.12.0",
+        "@types/json-schema": "^7.0.4",
+        "ajv": "^6.12.2",
         "ajv-keywords": "^3.4.1"
       }
     },
     "script-loader": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.2.tgz",
-      "integrity": "sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/script-loader/-/script-loader-0.7.2.tgz",
+      "integrity": "sha1-IBbbb4byX1z1baOJFdgzeLsWa6c=",
       "dev": true,
       "requires": {
         "raw-loader": "~0.5.1"
@@ -5008,13 +4869,13 @@
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
       "dev": true
     },
     "semver-dsl": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/semver-dsl/-/semver-dsl-1.0.1.tgz",
       "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
       "dev": true,
       "requires": {
@@ -5023,20 +4884,20 @@
     },
     "serialize-javascript": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -5047,7 +4908,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -5058,14 +4919,14 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -5074,7 +4935,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -5083,26 +4944,20 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
         "base": "^0.11.1",
@@ -5117,7 +4972,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5126,7 +4981,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -5137,8 +4992,8 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
         "define-property": "^1.0.0",
@@ -5148,7 +5003,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -5157,8 +5012,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -5166,8 +5021,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -5175,8 +5030,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -5186,22 +5041,22 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         }
       }
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
@@ -5209,20 +5064,20 @@
     },
     "source-list-map": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
       "dev": true
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-loader": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
-      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha1-wYsNxuI79m9nkkN1V8VpoR4HInE=",
       "dev": true,
       "requires": {
         "async": "^2.5.0",
@@ -5231,20 +5086,20 @@
       "dependencies": {
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -5252,8 +5107,8 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -5265,8 +5120,8 @@
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "dev": true,
       "requires": {
         "atob": "^2.1.2",
@@ -5278,8 +5133,8 @@
     },
     "source-map-support": {
       "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -5288,22 +5143,22 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -5311,14 +5166,14 @@
     },
     "sprintf-js": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha1-2hdlJiv4wPVxdJ8q1sJjACB65nM=",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -5334,8 +5189,8 @@
     },
     "ssri": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ssri/-/ssri-7.1.0.tgz",
+      "integrity": "sha1-ksJBv23oI2W1x/tL126XVSLhKU0=",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1",
@@ -5344,7 +5199,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -5354,7 +5209,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5365,8 +5220,8 @@
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
       "dev": true,
       "requires": {
         "inherits": "~2.0.1",
@@ -5375,8 +5230,8 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -5385,8 +5240,8 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -5398,14 +5253,14 @@
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
       "dev": true
     },
     "string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
       "dev": true,
       "requires": {
         "emoji-regex": "^7.0.1",
@@ -5415,14 +5270,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -5432,8 +5287,8 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -5441,23 +5296,17 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
-    },
     "style-loader": {
       "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.21.0.tgz",
-      "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/style-loader/-/style-loader-0.21.0.tgz",
+      "integrity": "sha1-aMUuXrKvycqStidL4nfuWa6jqFI=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
@@ -5466,20 +5315,20 @@
       "dependencies": {
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -5487,8 +5336,8 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -5498,8 +5347,8 @@
         },
         "schema-utils": {
           "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha1-unT1l9K+LqiAExdG7hfQoJPGgYc=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -5510,20 +5359,20 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "tapable": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
       "dev": true
     },
     "terser": {
-      "version": "4.6.13",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
-      "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
+      "version": "4.8.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -5533,23 +5382,23 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+      "integrity": "sha1-LGNUQ0cyS6r6mla6rd8WNMir/C8=",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^3.1.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -5558,8 +5407,8 @@
       "dependencies": {
         "cacache": {
           "version": "12.0.4",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-          "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/cacache/-/cacache-12.0.4.tgz",
+          "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -5581,8 +5430,8 @@
         },
         "find-cache-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -5592,8 +5441,8 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -5601,8 +5450,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -5611,8 +5460,8 @@
         },
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -5621,8 +5470,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -5630,14 +5479,14 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -5645,8 +5494,8 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -5654,16 +5503,25 @@
             "ajv-keywords": "^3.1.0"
           }
         },
+        "serialize-javascript": {
+          "version": "3.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -5673,14 +5531,14 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -5689,8 +5547,8 @@
     },
     "timers-browserify": {
       "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -5698,13 +5556,13 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -5713,8 +5571,8 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
         "define-property": "^2.0.2",
@@ -5725,7 +5583,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -5735,7 +5593,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -5746,14 +5604,14 @@
     },
     "tokenizr": {
       "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/tokenizr/-/tokenizr-1.5.7.tgz",
-      "integrity": "sha512-w6qS6F5PNtY30DxoRD4a7nC7zOlPM2SlpQ4zLhOmqBaB1VCZrlV82bLpc/lKNOdNmrwIwcsJLDcjEJ8f7UG6Mg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tokenizr/-/tokenizr-1.5.7.tgz",
+      "integrity": "sha1-gHAndaydYYmb08YOTHrDa5hFvL8=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "dev": true,
       "requires": {
         "psl": "^1.1.28",
@@ -5762,8 +5620,8 @@
     },
     "ts-loader": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-4.4.2.tgz",
-      "integrity": "sha512-Z3Y1a7A0KZZ1s/mAZkt74l1NAF7Y5xUhD1V9VB8/1eUlUOk8Qa/oo46tO2Uu5kQ3wXypOlbv77lLQySjXEDcdw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ts-loader/-/ts-loader-4.4.2.tgz",
+      "integrity": "sha1-d41EZLJENoc8ePf56RTYgZTCokg=",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -5775,8 +5633,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -5784,26 +5642,26 @@
         },
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -5820,7 +5678,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -5831,8 +5689,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -5842,13 +5700,13 @@
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
@@ -5863,7 +5721,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -5872,7 +5730,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -5881,7 +5739,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -5890,7 +5748,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -5901,7 +5759,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -5910,7 +5768,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -5921,8 +5779,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
@@ -5932,16 +5790,16 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -5956,7 +5814,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -5965,7 +5823,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -5976,7 +5834,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -5988,7 +5846,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -5999,8 +5857,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -6008,8 +5866,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -6017,8 +5875,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -6028,7 +5886,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -6037,7 +5895,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -6048,14 +5906,14 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -6063,14 +5921,14 @@
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -6080,8 +5938,8 @@
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -6101,8 +5959,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -6112,8 +5970,8 @@
     },
     "tsickle": {
       "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.29.0.tgz",
-      "integrity": "sha512-JpID0Lv8/irRtPmqJJxb5fCwfZhjZeKmav9Zna7UjqVuJoSbI49Wue/c2PPybX1SbRrjl7bbI/JsCl0dSUJygA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tsickle/-/tsickle-0.29.0.tgz",
+      "integrity": "sha1-gSgGVUu0bBqhbrD+KgUdqVyo9aQ=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0",
@@ -6124,21 +5982,21 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
     },
     "tslib": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM=",
       "dev": true
     },
     "tslint": {
       "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tslint/-/tslint-5.10.0.tgz",
       "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
       "dev": true,
       "requires": {
@@ -6158,8 +6016,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -6167,8 +6025,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -6178,8 +6036,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -6189,8 +6047,8 @@
     },
     "tslint-react": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-4.0.0.tgz",
-      "integrity": "sha512-9fNE0fm9zNDx1+b6hgy8rgDN2WsQLRiIrn3+fbqm0tazBVF6jiaCFAITxmU+WSFWYE03Xhp1joCircXOe1WVAQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tslint-react/-/tslint-react-4.0.0.tgz",
+      "integrity": "sha1-tLtMAcMkSMsU0j8UOi9eSYm7lh4=",
       "dev": true,
       "requires": {
         "tsutils": "^3.9.1"
@@ -6198,8 +6056,8 @@
       "dependencies": {
         "tsutils": {
           "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha1-7XGZF/EcoN7lhicrKsSeAVot11k=",
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"
@@ -6209,8 +6067,8 @@
     },
     "tsutils": {
       "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -6218,13 +6076,13 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -6233,60 +6091,32 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typeface-roboto": {
       "version": "0.0.75",
-      "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-0.0.75.tgz",
-      "integrity": "sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/typeface-roboto/-/typeface-roboto-0.0.75.tgz",
+      "integrity": "sha1-mNW6NewjS7xxcjdMgpcncJnMcSs=",
       "dev": true
     },
     "typescript": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
-      "dev": true
-    },
-    "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true
-    },
-    "unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dev": true,
-      "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      }
-    },
-    "unicode-match-property-value-ecmascript": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
-      "dev": true
-    },
-    "unicode-property-aliases-ecmascript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha1-LWFaHvSu5PV0Qlzf9wJu34GRmDY=",
       "dev": true
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -6297,8 +6127,8 @@
     },
     "unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
@@ -6306,8 +6136,8 @@
     },
     "unique-slug": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -6315,7 +6145,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -6325,7 +6155,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -6336,7 +6166,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -6347,13 +6177,13 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -6361,14 +6191,15 @@
     },
     "upath": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
+      "dev": true,
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -6376,13 +6207,13 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -6392,7 +6223,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -6400,8 +6231,8 @@
     },
     "url-loader": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.0.1.tgz",
-      "integrity": "sha512-rAonpHy7231fmweBKUFe0bYnlGDty77E+fm53NZdij7j/YOpyGzc7ttqG1nAXl3aRs0k41o0PC3TvGXQiw2Zvw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/url-loader/-/url-loader-1.0.1.tgz",
+      "integrity": "sha1-YbxT8fGE1zQ9onKKEonvhyLqRe4=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
@@ -6411,20 +6242,20 @@
       "dependencies": {
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -6432,8 +6263,8 @@
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -6443,8 +6274,8 @@
         },
         "schema-utils": {
           "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha1-unT1l9K+LqiAExdG7hfQoJPGgYc=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -6455,14 +6286,14 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/use/-/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util/-/util-0.11.1.tgz",
+      "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
@@ -6470,7 +6301,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -6478,25 +6309,25 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-      "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+      "version": "2.1.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha1-VLw83UMxe8qR413K8wWxpyN950U=",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -6507,26 +6338,173 @@
     },
     "vm-browserify": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
       "dev": true
     },
     "watchpack": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
-      "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
+      "version": "1.7.4",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha1-bp2lOzyAuy1lCBiPWyAEEIZs0ws=",
       "dev": true,
       "requires": {
-        "chokidar": "^2.1.8",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-3.4.1.tgz",
+          "integrity": "sha1-6QW97PEOqgoLHbDGZEgcxMvCK6E=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true,
+          "optional": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+          "dev": true,
+          "optional": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+          "dev": true,
+          "optional": true
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha1-mUihhmy71suCTeoTp+1pH2yN3/A=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
       },
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
           "dev": true,
+          "optional": true,
           "requires": {
             "micromatch": "^3.1.4",
             "normalize-path": "^2.1.1"
@@ -6534,9 +6512,10 @@
           "dependencies": {
             "normalize-path": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "remove-trailing-separator": "^1.0.1"
               }
@@ -6545,21 +6524,24 @@
         },
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -6575,9 +6557,10 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6586,9 +6569,10 @@
         },
         "chokidar": {
           "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
@@ -6606,9 +6590,10 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -6621,36 +6606,40 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -6659,18 +6648,20 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -6679,9 +6670,10 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -6690,17 +6682,19 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+              "dev": true,
+              "optional": true
             }
           }
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -6714,18 +6708,20 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6734,9 +6730,10 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -6746,9 +6743,10 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6757,9 +6755,10 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -6767,9 +6766,10 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extglob": "^2.1.0"
               }
@@ -6778,27 +6778,30 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -6807,33 +6810,37 @@
         },
         "is-extglob": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -6842,21 +6849,24 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "dev": true
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+          "dev": true,
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -6875,16 +6885,17 @@
         },
         "normalize-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "webpack": {
       "version": "4.41.6",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
-      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha1-EvL4BL9lQu8WZ1UFDUr7yPZrp+E=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -6914,26 +6925,26 @@
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -6950,7 +6961,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -6961,13 +6972,13 @@
         },
         "emojis-list": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
           "dev": true
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
@@ -6982,7 +6993,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -6991,7 +7002,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -7000,7 +7011,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -7009,7 +7020,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -7020,7 +7031,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -7029,7 +7040,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -7040,8 +7051,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
@@ -7051,16 +7062,16 @@
             },
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -7075,7 +7086,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -7084,7 +7095,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -7095,7 +7106,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -7107,7 +7118,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -7118,8 +7129,8 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -7127,8 +7138,8 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -7136,8 +7147,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -7147,7 +7158,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -7156,7 +7167,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -7167,14 +7178,14 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -7182,14 +7193,14 @@
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
           "dev": true
         },
         "loader-utils": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -7199,7 +7210,7 @@
         },
         "memory-fs": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/memory-fs/-/memory-fs-0.4.1.tgz",
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "dev": true,
           "requires": {
@@ -7209,8 +7220,8 @@
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -7230,8 +7241,8 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
             "ajv": "^6.1.0",
@@ -7242,28 +7253,28 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
-      "integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
+      "version": "3.3.12",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-cli/-/webpack-cli-3.3.12.tgz",
+      "integrity": "sha1-lOmtoIFFPNCqYJyZ5QABL9OtLUo=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "enhanced-resolve": "4.1.0",
-        "findup-sync": "3.0.0",
-        "global-modules": "2.0.0",
-        "import-local": "2.0.0",
-        "interpret": "1.2.0",
-        "loader-utils": "1.2.3",
-        "supports-color": "6.1.0",
-        "v8-compile-cache": "2.0.3",
-        "yargs": "13.2.4"
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "enhanced-resolve": "^4.1.1",
+        "findup-sync": "^3.0.0",
+        "global-modules": "^2.0.0",
+        "import-local": "^2.0.0",
+        "interpret": "^1.4.0",
+        "loader-utils": "^1.4.0",
+        "supports-color": "^6.1.0",
+        "v8-compile-cache": "^2.1.1",
+        "yargs": "^13.3.2"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -7271,14 +7282,14 @@
         },
         "big.js": {
           "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -7288,8 +7299,8 @@
           "dependencies": {
             "supports-color": {
               "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
               "dev": true,
               "requires": {
                 "has-flag": "^3.0.0"
@@ -7297,51 +7308,36 @@
             }
           }
         },
-        "enhanced-resolve": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-          "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.4.0",
-            "tapable": "^1.0.0"
-          }
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
+          "dev": true
         },
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+          "version": "1.4.0",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
+            "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
-          }
-        },
-        "memory-fs": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-          "dev": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
           }
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -7351,8 +7347,8 @@
     },
     "webpack-log": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
       "dev": true,
       "requires": {
         "ansi-colors": "^3.0.0",
@@ -7361,8 +7357,8 @@
     },
     "webpack-sources": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
       "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",
@@ -7371,16 +7367,16 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -7388,14 +7384,14 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
@@ -7403,8 +7399,8 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -7414,14 +7410,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -7429,8 +7425,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -7440,57 +7436,56 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "xmldom": {
       "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha1-t2yaG9nwqXN+WnLcNyMc84N14v8=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
       "dev": true
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "dev": true
     },
     "yargs": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-      "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+      "version": "13.3.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^2.0.1",
-        "os-locale": "^3.1.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.0"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -7498,8 +7493,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -7508,8 +7503,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -7517,7 +7512,7 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -7525,8 +7520,8 @@
     },
     "yargs-parser": {
       "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
@@ -7535,8 +7530,8 @@
     },
     "zone.js": {
       "version": "0.8.29",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.29.tgz",
-      "integrity": "sha512-mla2acNCMkWXBD+c+yeUrBUrzOxYMNFdQ6FGfigGGtEVBPJx07BQeJekjt9DmH1FtZek4E9rE1eRR9qQpxACOQ==",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/zone.js/-/zone.js-0.8.29.tgz",
+      "integrity": "sha1-jc6Sqg3VU7ULxb+7kK+Zhq2EWhI=",
       "dev": true
     }
   }

--- a/virtual-desktop/package.json
+++ b/virtual-desktop/package.json
@@ -29,6 +29,7 @@
     "@angular/router": "~6.0.9",
     "@types/html2canvas": "~0.0.35",
     "@zlux/widgets": "git+https://github.com/zowe/zlux-widgets.git",
+    "@types/xmldom": "0.1.29",
     "angular-l10n": "~5.2.0",
     "angular2-template-loader": "~0.6.2",
     "bootstrap": "~4.3.1",

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -62,9 +62,10 @@ export class IFramePluginFactory extends PluginFactory {
     let startingPageUri;
     if (startingPage.startsWith('http://') || startingPage.startsWith('https://')) {
       startingPageUri = startingPage;
-    } else {
+    } else if (!startingPage.startsWith('/')) { //don't touch absolute paths in case they are intended to reach an APIML route
       startingPageUri = (window as any).ZoweZLUX.uriBroker.pluginResourceUri(basePlugin, startingPage);
-    }
+    } // else { TODO URLs in the form of ${APIML}/ or ${my.plugin.id}/ could be used to provide smarter iframe routing, via knowledge of Uribroker.
+
     this.logger.debug('ZWED5308I', startingPageUri); //this.logger.debug('iframe startingPageUri', startingPageUri);
     const safeStartingPageUri: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(startingPageUri);
     this.logger.info(`ZWED5053I`, startingPageUri); //this.logger.info(`Loading iframe, URI=${startingPageUri}`);

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -64,7 +64,9 @@ export class IFramePluginFactory extends PluginFactory {
       startingPageUri = startingPage;
     } else if (!startingPage.startsWith('/')) { //don't touch absolute paths in case they are intended to reach an APIML route
       startingPageUri = (window as any).ZoweZLUX.uriBroker.pluginResourceUri(basePlugin, startingPage);
-    } // else { TODO URLs in the form of ${APIML}/ or ${my.plugin.id}/ could be used to provide smarter iframe routing, via knowledge of Uribroker.
+    } else { //TODO URLs in the form of ${APIML}/ or ${my.plugin.id}/ could be used to provide smarter iframe routing, via knowledge of Uribroker.
+      startingPageUri = startingPage;
+    }
 
     this.logger.debug('ZWED5308I', startingPageUri); //this.logger.debug('iframe startingPageUri', startingPageUri);
     const safeStartingPageUri: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(startingPageUri);


### PR DESCRIPTION
If an iframe is for something on the apiml, then when the desktop is being accessed through apiml, the route could start with `/` so that the iframe app does not need hardcoded knowledge of the api gateway host & port.
This would also work equally well for specification of explicit paths to the app server.
Care must be taken to distinguish those two, as both abilities cannot be used at once.
In the future, we can expand upon this with env-var-like statements in the string to hint at the desired destination.

now depends upon https://github.com/zowe/zlux-platform/pull/63

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>