### PR TITLE
(WIP) New QA ids for desktop elements

### DIFF
--- a/system-apps/system-settings-preferences/webClient/src/app/language/language.component.html
+++ b/system-apps/system-settings-preferences/webClient/src/app/language/language.component.html
@@ -10,17 +10,50 @@
 <div class="language-main-window">
   <div class="language-content-left">
       <img class="language-icon" alt=""><hr class="language-separator-hor">
-      <button class="language-button" (click)="selectEnglish()" title="{{Select}}">English</button><hr class="language-separator-hor">
-      <button class="language-button" (click)="selectChinese()" title="{{Select}}">中文</button><hr class="language-separator-hor">
-      <button class="language-button" (click)="selectFrench()" title="{{Select}}">Français</button><hr class="language-separator-hor">
-      <button class="language-button" (click)="selectJapanese()" title="{{Select}}">日本語</button><hr class="language-separator-hor">
-      <button class="language-button" (click)="selectRussian()" title="{{Select}}">Pусский</button><hr class="language-separator-hor">
-      <button class="language-button" (click)="selectGerman()" title="{{Select}}">Deutsch</button><hr class="language-separator-hor">
+      <button 
+        class="language-button" 
+        (click)="selectEnglish()" 
+        title="{{Select}}"
+        id="ZAP_Languages_SelectEnglish">English</button>
+      <hr class="language-separator-hor">
+      <button 
+        class="language-button" 
+        (click)="selectChinese()" 
+        title="{{Select}}"
+        id="ZAP_Languages_SelectChinese">中文</button>
+      <hr class="language-separator-hor">
+      <button 
+        class="language-button" 
+        (click)="selectFrench()" 
+        title="{{Select}}"
+        id="ZAP_Languages_SelectFrench">Français</button>
+      <hr class="language-separator-hor">
+      <button 
+        class="language-button" 
+        (click)="selectJapanese()" 
+        title="{{Select}}"
+        id="ZAP_Languages_SelectJapanese">日本語</button>
+      <hr class="language-separator-hor">
+      <button 
+        class="language-button" 
+        (click)="selectRussian()" 
+        title="{{Select}}"
+        id="ZAP_Languages_SelectRussian">Pусский</button>
+      <hr class="language-separator-hor">
+      <button 
+        class="language-button" 
+        (click)="selectGerman()" 
+        title="{{Select}}"
+        id="ZAP_Languages_SelectGerman">Deutsch</button>
+      <hr class="language-separator-hor">
   </div>
   <div class="language-content-right">
     
-    <label class="language-label"> {{LanguageSelected}}: {{selectedLanguage}}</label>
-    <button type="submit" class="language-submit" (click)="applyLanguage()">{{Apply}}</button>
+    <label class="language-label" id="ZAP_Languages_SelectedLabel"> {{LanguageSelected}}: {{selectedLanguage}}</label>
+    <button type="submit" 
+      class="language-submit" 
+      (click)="applyLanguage()"
+      id="ZAP_Languages_ApplyButton">{{Apply}}</button>
   </div>
 </div>
 

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.html
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.html
@@ -16,29 +16,43 @@
 
 <div class="login-panel" [class.hidden]="!isLoading && !needLogin && !changePassword">
   <div class="login-overlay" src="'../../../assets/images/login/back-button.png'">
-      <button class="back-button" [hidden]="!changePassword && !expiredPassword" (click)="backButton()">{{this.translation.translate("Back")}}</button>
+      <button class="back-button" 
+        [hidden]="!changePassword && !expiredPassword" 
+        (click)="backButton()"
+        id="ZAP_LoginPage_BackButton">{{this.translation.translate("Back")}}</button>
     <div>
     <img class="logo-img" [hidden]="changePassword || expiredPassword" [src]="logo" alt="Zowe - z/OS Lightweight User Experience" />
     <img class="password-logo-img" [hidden]="!changePassword && !expiredPassword" [src]="passwordLogo" alt="Zowe - z/OS Lightweight User Experience" />
     <form class="login-form" [class.login-form-expired]="expiredPassword" [class.password-login-form]="changePassword">
       <p class="login-message">{{loginMessage}}</p>
       <label [hidden]="changePassword" for="userid" i18n="label|Label for username@@username-label">Username</label>
-      <input [hidden]="changePassword" class="userid" id="usernameInput" aria-labelledby="user id" tabindex="1" type="text" name="userid" [(ngModel)]="username" minlength="1" maxlength="100" autofocus [attr.disabled]="locked?'':null" (keyup)="considerSubmit($event)"/>
+      <input 
+        [hidden]="changePassword" class="userid" id="ZAP_LoginPage_Username" aria-labelledby="user id" tabindex="1" type="text" 
+        name="userid" [(ngModel)]="username" minlength="1" maxlength="100" autofocus [attr.disabled]="locked?'':null" 
+        (keyup)="considerSubmit($event)"/>
       <label for="password" i18n="label|Label for password@@password-label">{{this.expiredPassword ? "Old Password" : "Password"}}</label>
-      <input class="password" id="passwordInput" aria-labelledby="password" tabindex="1" type="password" name="password"[(ngModel)]="password" maxlength="100" [attr.disabled]="locked?'':null" (keyup)="considerSubmit($event)"/>
+      <input 
+        class="password" id="ZAP_LoginPage_Password" aria-labelledby="password" tabindex="1" type="password" 
+        name="password"[(ngModel)]="password" maxlength="100" [attr.disabled]="locked?'':null" (keyup)="considerSubmit($event)"/>
       <label [hidden]="!expiredPassword && !changePassword" for="newPassword" i18n="label|Label for password@@new-password-label">New Password</label>
-      <input [hidden]="!expiredPassword && !changePassword" class="newPassword" id="newPasswordInput" aria-labelledby="newPassword" tabindex="1" type="password" name="newPassword"[(ngModel)]="newPassword" maxlength="100" [attr.disabled]="locked?'':null" (keyup)="considerSubmit($event)"/>
+      <input 
+        [hidden]="!expiredPassword && !changePassword" class="newPassword" id="ZAP_LoginPage_NewPassword" aria-labelledby="newPassword" 
+        tabindex="1" type="password" name="newPassword"[(ngModel)]="newPassword" maxlength="100" [attr.disabled]="locked?'':null" 
+        (keyup)="considerSubmit($event)"/>
       <label [hidden]="!expiredPassword && !changePassword" for="confirmNewPassword" i18n="label|Label for password@@confirm-new-password-label">Confirm New Password</label>
-      <input [hidden]="!expiredPassword && !changePassword" class="confirmNewPassword" id="confirmNewPasswordInput" aria-labelledby="confirmNewPassword" tabindex="1" type="password" name="confirmNewPassword"[(ngModel)]="confirmNewPassword" maxlength="100" [attr.disabled]="locked?'':null" (keyup)="considerSubmit($event)"/>
+      <input 
+        [hidden]="!expiredPassword && !changePassword" class="confirmNewPassword" id="ZAP_LoginPage_ConfirmNewPassword" 
+        aria-labelledby="confirmNewPassword" tabindex="1" type="password" name="confirmNewPassword"[(ngModel)]="confirmNewPassword" 
+        maxlength="100" [attr.disabled]="locked?'':null" (keyup)="considerSubmit($event)"/>
     </form>
     <p class="login-error">{{this.translation.translate(errorMessage)}}</p>
     <div class="fa fa-spinner fa-spin fa-5x" [hidden]="!isLoading"></div>
-    <button [hidden]="!expiredPassword && !changePassword"
-            class="login-button" (click)="attemptPasswordReset()" [disabled]="locked">
+    <button id="ZAP_LoginPage_SavePassword"
+      [hidden]="!expiredPassword && !changePassword" class="login-button" (click)="attemptPasswordReset()" [disabled]="locked">
             {{this.expiredPassword ? this.translation.translate("Change Password") : this.translation.translate("SavePassword")}}
     </button>
     <div>
-      <button id="#org.zowe.zlux.ng2desktop_loginButton"
+      <button id="ZAP_LoginPage_Login"
         class="login-button"
         (click)="attemptLogin()"
         [hidden]="!needLogin || expiredPassword"
@@ -48,7 +62,7 @@
       </button>
     </div>
   </div>
-  <span class="login-plugin-version">{{getPluginVersion()}}</span>
+  <span class="login-plugin-version" id="ZAP_LoginPage_Version">{{getPluginVersion()}}</span>
   </div>
 </div>
 

--- a/virtual-desktop/src/app/context-menu/context-menu.component.html
+++ b/virtual-desktop/src/app/context-menu/context-menu.component.html
@@ -17,6 +17,7 @@
   [style.top.px]='this.newY'
   [class.propagateChildLeft]="this._propagateChildLeft"
   [class.navigable]='this.isNavigable'
+  id="ZAP_ContextMenu_Panel"
 >
   <ul>
     <ng-container *ngFor='let menuItem of menuItems; let i = index;'>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.html
@@ -14,7 +14,8 @@
   <div class="mvd-launchbar-icon mvd-launchbar-icon-large launchbar-menu-icon"
        [style.width]="menuIconSize"
        [style.height]="menuIconSize"
-       (click)="activeToggle()"></div>
+       (click)="activeToggle()"
+       id="ZAP_DesktopHome_ZoweStart"></div>
 </div>
 
 <ng-template [ngIf]="isActive">
@@ -24,7 +25,10 @@
        [style.width]="menuWidth"
        [style.bottom]="menuBottom"
        (click)="setSearchFocus();">
-    <div style="cursor: pointer" class="refresh-plugins" (click)="refresh()">
+    <div style="cursor: pointer" 
+      class="refresh-plugins" 
+      (click)="refresh()"
+      id="ZAP_DesktopHome_RefreshApplications">
       {{translation.translate("Refresh Applications")}}
       <em style="padding: 5px" class="fa fa-refresh" (click)="refresh()"></em>
     </div>
@@ -56,7 +60,8 @@
         [style.font-size]="menuText"
         [style.color]="color.launchbarMenuText"
         [(ngModel)]="appFilter"
-        (input)="filterMenuItems()">
+        (input)="filterMenuItems()"
+        id="ZAP_DesktopHome_SearchApplications">
     </div>
   </div>
 </ng-template>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.html
@@ -12,16 +12,17 @@
      [style.background]="color.launchbarMenuColor"
      [style.bottom]="popupBottom"
      [style.color]="color.launchbarMenuText">
-  <h5 class="launchbar-username">{{getUsername()}}</h5>
-  <button #logoutbutton class="btn btn-primary launchbar-button" (click)="logout()"
+  <h5 class="launchbar-username" id="ZAP_DesktopHome_UsernameLabel">{{getUsername()}}</h5>
+  <button #logoutbutton class="btn btn-primary launchbar-button" (click)="logout()" id="ZAP_DesktopHome_LogoutButton"
     i18n="signout button|Title of Sign out button@@signout-button-title">Log out</button>
-  <h6 class="launchbar-plugin-version" [style.color]="color.launchbarMenuText">{{getPluginVersion()}}</h6>
+  <h6 class="launchbar-plugin-version" [style.color]="color.launchbarMenuText" id="ZAP_DesktopHome_VersionLabel">{{getPluginVersion()}}</h6>
 </div>
 
 <div #notificationarea [hidden]="!notificationsVisible" class='notifications'
      [style.bottom]="popupBottom"
      [style.background]="color.launchbarMenuColor"
-     [style.color]="color.launchbarMenuText">
+     [style.color]="color.launchbarMenuText"
+     id="ZAP_DesktopHome_NotificationsPanel">
   <div [hidden]="notifications.length > 0" class="no-notifications">{{NoNotifications}}</div>
   <div class="notification-item" *ngFor="let item of notifications; let i = index" [attr.data-index]="i">
       <div class="outer-container" (click)="focusApplication(i)">
@@ -29,10 +30,14 @@
             <img class="notification-icon" [src]="info[i].imgSrc" alt="">
           </div>
           <div class="notification-content">
-            <div class="notification-title">{{item['notification'].title}}</div>
-            <div class="notification-message">{{item['notification'].message}}</div>
+            <div class="notification-title" id="ZAP_DesktopHome_NotificationsTitle">{{item['notification'].title}}</div>
+            <div class="notification-message" id="ZAP_DesktopHome_NotificationsMessage">{{item['notification'].message}}</div>
           </div>
-          <img class="delete-notification" (click)="deleteNotification(item);$event.stopPropagation()" [src]="closeImage" alt="Delete notification">
+          <img class="delete-notification" 
+            (click)="deleteNotification(item);$event.stopPropagation()" 
+            [src]="closeImage" 
+            alt="Delete notification"
+            id="ZAP_DesktopHome_NotificationsDelete">
           <div class="time-container">
             <div class="time">{{item.recievedDate.toLocaleTimeString()}}</div>
             <div class="timeAgo">{{timeSince[i]}}</div>
@@ -45,11 +50,12 @@
 <div class="widget-area"
      [style.min-width]="areaSize"
      [style.background]="color.launchbarColor"
-     [style.border-radius]="borderRadius">
-  <div class="clock two-row" *ngIf="clockTwoRow" [style.font-size]="fontSize" [style.padding-top]="clockOffset">
-    <span>{{date | date:'shortTime'}}</span>
+     [style.border-radius]="borderRadius"
+     id="ZAP_DesktopHome_WidgetArea">
+  <div class="clock two-row" *ngIf="clockTwoRow" [style.font-size]="fontSize" [style.padding-top]="clockOffset" id="ZAP_DesktopHome_LaunchbarClock">
+    <span id="ZAP_DesktopHome_TimeLabel">{{date | date:'shortTime'}}</span>
     <br>
-    <span>{{date | date:'shortDate'}}</span>
+    <span id="ZAP_DesktopHome_DateLabel">{{date | date:'shortDate'}}</span>
   </div>
   <div class="clock" *ngIf="!clockTwoRow" [style.font-size]="fontSize" [style.padding-top]="clockOffset">
     <span>{{date | date:'shortDate'}} {{date | date:'shortTime'}}</span>
@@ -59,7 +65,8 @@
        [style.background-size]="widgetSize+' '+widgetSize"
        [style.height]="widgetSize"
        [style.width]="widgetSize"
-       (click)="toggleNotifications()">
+       (click)="toggleNotifications()"
+       id="ZAP_DesktopHome_NotificationsIcon">
       <div 
         [hidden]="notifications.length == 0"
         class="launchbar-tray-indicator"
@@ -75,13 +82,15 @@
        [style.background-size]="widgetSize+' '+widgetSize"
        [style.height]="widgetSize"
        [style.width]="widgetSize"
-       (click)="togglePersonalizationPanel()"></div>
+       (click)="togglePersonalizationPanel()"
+       id="ZAP_DesktopHome_SettingsIcon"></div>
   <div #usericon class="launchbar-tray-icon user"
        [style.margin-top]="widgetOffset"
        [style.height]="widgetSize"
        [style.width]="widgetSize"
        [style.background-size]="widgetSize+' '+widgetSize"
-       (click)="togglePopup()"></div>
+       (click)="togglePopup()"
+       id="ZAP_DesktopHome_UserIcon"></div>
 </div>
 
 <!--

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
@@ -15,10 +15,12 @@
      (mouseup)="onMouseUpContainer($event)" [class.active]="isActive">
   <rs-com-launchbar-menu [menuItems]="allItems" [theme]="_theme" (itemClicked)="menuItemClicked($event)"  (refreshClicked)="getNewItems()"></rs-com-launchbar-menu>
   
-  <div class="applist row" [style.margin]="applistMargin"
-       [style.background]="_theme.color.launchbarColor"
-       [style.padding-left]="applistPadding"
-       [style.border-radius]="applistPadding">
+  <div class="applist row" 
+    [style.margin]="applistMargin"
+    [style.background]="_theme.color.launchbarColor"
+    [style.padding-left]="applistPadding"
+    [style.border-radius]="applistPadding"
+    id="ZAP_DesktopHome_Launchbar">
     <rs-com-launchbar-icon *ngFor="let item of pinnedItems" [launchbarItem]="item" [theme]="_theme" (contextmenu)="onRightClick($event, item)"
     (mousedown)="onMouseDown($event, item)" (mousemove)="onMouseMove($event, item)">
     </rs-com-launchbar-icon>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/personalization-panel/personalization-panel.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/personalization-panel/personalization-panel.component.html
@@ -13,10 +13,11 @@
   (mouseenter)="panelMouseEnter()" 
   (mouseleave)="panelMouseLeave()"
   [style.width]='this.panelWidth'
-  [style.maxWidth]='this.panelMaxWidth'>
+  [style.maxWidth]='this.panelMaxWidth'
+  id="ZAP_DesktopHome_Settings_Panel">
     <ul class="personalization-panel-ul" *ngIf="showPanel">
       <li class="personalization-panel-li" *ngFor="let tool of personalizationTools" (click)="openTool(tool)">
-        <img class="personalization-panel-item panel-item-{{tool.imgSrc}}" alt=""><br>
+        <img class="personalization-panel-item panel-item-{{tool.imgSrc}}" alt="" id="ZAP_DesktopHome_Settings_{{tool.imgSrc}}Icon"><br>
         <span class="personalization-panel-span">{{tool.title}}</span>
       </li>
     </ul>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/personalization-panel/personalization/personalization.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/personalization-panel/personalization/personalization.component.html
@@ -10,17 +10,18 @@
 
 <!-- TODO: This page needs internationalization support -->
 <div class="personalization-main-window">
-  <label class="personalization-label small back-button top" (click)="goBack()">
+  <label class="personalization-label small back-button top" (click)="goBack()" id="ZAP_Personalization_BackButton">
     <em class="fa fa-chevron-left" style="padding: 5px; font-size: large; padding-right: 7px; margin-top: 2px;"></em>{{Back}}
   </label>
 
-  <label class="personalization-label small reset-button top" (click)="resetAllDefault()">{{ResetToDefault}}
+  <label class="personalization-label small reset-button top" (click)="resetAllDefault()" id="ZAP_Personalization_ResetButton">{{ResetToDefault}}
     <em class="fa fa-trash" style="padding: 5px; font-size: large;"></em>
   </label>
 
   <label class="personalization-label" style="padding-top: 10px;">{{Background}}</label>
 
   <file-drop 
+    id="ZAP_Personalization_FileDrop"
     (onFileDrop)="fileDrop($event)" 
     multiple="false"
     style="color: white !important;"
@@ -31,7 +32,7 @@
     </file-drop>
 
   <label class="personalization-label">{{Color}}</label>
-  <div class="personalization-color-1"> <!-- Color circle group -->
+  <div class="personalization-color-1" id="ZAP_Personalization_ColorCircleGroup"> <!-- Color circle group -->
     <div class="personalization-text" style="margin-left: -15px;">{{SelectColor}}</div>
     <canvas #circle1 width="40" height="40" [ngClass]="{ 'personalization-circle selected': selectedCircle == 1,
       'personalization-circle': true}" (click)="clickCircle(1)"></canvas>
@@ -70,12 +71,12 @@
     <canvas #circle18 width="40" height="40" [ngClass]="{ 'personalization-circle selected': selectedCircle == 18,
       'personalization-circle': true}" (click)="clickCircle(18)"></canvas>
   </div>
-  <div class="personalization-color-2"> <!-- Hue slider -->
+  <div class="personalization-color-2" id="ZAP_Personalization_HueSlider"> <!-- Hue slider -->
     <div class="personalization-text">{{OrHue}}</div>
     <canvas #slider1 width="389" height="14" (click)="clickSlider($event)"></canvas>
   </div>
   <div class="personalization-text">{{SelectLightness}}</div>
-  <div class="personalization-color-3"> <!-- Lightness swatches bar -->
+  <div class="personalization-color-3" id="ZAP_Personalization_LightnessBar"> <!-- Lightness swatches bar -->
     <div [ngClass]="{ 'personalization-swatch selected': selectedLightness == .8,
       'personalization-swatch': true}" id="swatch1" (click)=clickLightness(0.8) [ngStyle]="swatch1Style"></div>
     <div [ngClass]="{ 'personalization-swatch selected': selectedLightness == .65,
@@ -91,11 +92,11 @@
 
   <!-- Ideally, this would say something like alt="Select Size small" but alt attribute adds a weird artifact -->
   <img [ngClass]="{ 'personalization-preview-item selected': selectedSize == 1,
-    'personalization-preview-item preview-small': true}" (click)="sizeSelected('small')" alt="">
+    'personalization-preview-item preview-small': true}" (click)="sizeSelected('small')" alt="" id="ZAP_Personalization_SelectSmall">
   <img [ngClass]="{ 'personalization-preview-item selected': selectedSize == 2,
-    'personalization-preview-item preview-medium': true}" (click)="sizeSelected('medium')" alt="">
+    'personalization-preview-item preview-medium': true}" (click)="sizeSelected('medium')" alt="" id="ZAP_Personalization_SelectMedium">
   <img [ngClass]="{ 'personalization-preview-item selected': selectedSize == 3,
-    'personalization-preview-item preview-large': true}" (click)="sizeSelected('large')" alt="">
+    'personalization-preview-item preview-large': true}" (click)="sizeSelected('large')" alt="" id="ZAP_Personalization_SelectLarge">
 
     <!-- TODO: Add text re-sizing functionality -->
   <!-- <label class="personalization-label">Text Size</label> -->

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window-pane/window-pane.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window-pane/window-pane.component.html
@@ -10,7 +10,7 @@
   Copyright Contributors to the Zowe Project.
 -->
 
-<div class="window-pane" [ngStyle]="wallpaper">
+<div class="window-pane" [ngStyle]="wallpaper" id="ZAP_DesktopHome_Wallpaper">
   <div *ngFor="let window of windows">
     <rs-com-mvd-window [desktopWindow]="window" [theme]="theme"></rs-com-mvd-window>
   </div>


### PR DESCRIPTION
- Provides QA ids for various desktop elements
- PR should be merged in combination with: https://github.com/zowe/zowe-install-packaging/pull/1561

Left to do: Context menu

```
Welcome login -

	Username field
	Password field
	Login button
	Version label
	Confirm password field
	Save password button

Desktop home - 	

Launchbar
Notifications icon
Settings & Preferences icon
	Widget panel –
	Languages –
		English
		Japanese
		Chinese
		French
		Russian
		German
		Apply button
		Language selected label
	Personalization –
		Go back button
		Reset to default button
		Upload button
		Personalization group 1
		Personalization group 2
		Personalization group 3
		Size small, medium, large
	Change password –
		Go back button
		Confirm password
		Save and exit button
		
User icon
Time label
Date label
Widget tray
Wallpaper image
Zowe start icon
	App menu – 
	
	Search bar field
	Refresh applications button
	Launch widget (active selection)
	Launch widget
		Context menu
		Menu item “Open”
		Menu item “Open in New Browser Tab”
		Menu item “Unpin from taskbar”
		Menu item “Properties”
```
Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>