### PR TITLE
Hide app tray + adjust maximize mode when single app mode activates

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
@@ -145,7 +145,8 @@ export class LaunchbarMenuComponent implements MVDHosting.LoginActionInterface{
   ngOnInit(): void {
     this.appKeyboard.keyUpEvent
       .subscribe((event:KeyboardEvent) => {
-        if (event.which === KeyCode.KEY_M) {
+        // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
+        if (event.which === KeyCode.KEY_M && !(window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
           this.activeToggle();
         }
     });

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
@@ -10,9 +10,12 @@
   Copyright Contributors to the Zowe Project.
 -->
 
-<div class="launchbar-container launchbar-large" id="container"
-     [style.height]="barSize"
-     (mouseup)="onMouseUpContainer($event)" [class.active]="isActive">
+<div class="launchbar-container launchbar-large" 
+  id="container"
+  [style.height]="barSize"
+  (mouseup)="onMouseUpContainer($event)" 
+  [class.active]="isActive"
+  [style.display]="displayAppBar">
   <rs-com-launchbar-menu [menuItems]="allItems" [theme]="_theme" (itemClicked)="menuItemClicked($event)"  (refreshClicked)="getNewItems()"></rs-com-launchbar-menu>
   
   <div class="applist row" 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
@@ -15,7 +15,7 @@
   [style.height]="barSize"
   (mouseup)="onMouseUpContainer($event)" 
   [class.active]="isActive"
-  [style.display]="displayAppBar">
+  *ngIf="displayAppBar">
   <rs-com-launchbar-menu [menuItems]="allItems" [theme]="_theme" (itemClicked)="menuItemClicked($event)"  (refreshClicked)="getNewItems()"></rs-com-launchbar-menu>
   
   <div class="applist row" 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -43,7 +43,7 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
 
   //Always 6+icon size, due to need for space for padding and such
   public barSize: string;
-  public displayAppBar: string;
+  public displayAppBar: boolean;
   public applistMargin: string;
   public applistPadding: string;
   public _theme: DesktopTheme;
@@ -78,9 +78,9 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
 
     // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
     if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-      this.displayAppBar = "none";
+      this.displayAppBar = false;
     } else {
-      this.displayAppBar = "inherit";
+      this.displayAppBar = true;
     }
   }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -43,6 +43,7 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
 
   //Always 6+icon size, due to need for space for padding and such
   public barSize: string;
+  public displayAppBar: string;
   public applistMargin: string;
   public applistPadding: string;
   public _theme: DesktopTheme;
@@ -73,6 +74,13 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
       this.applistPadding = '5px';
       this.applistMargin = `0px 179px 0px 46px`;
       break;
+    }
+
+    // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
+    if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+      this.displayAppBar = "none";
+    } else {
+      this.displayAppBar = "inherit";
     }
   }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -270,12 +270,17 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   }
 
   private refreshMaximizedWindowSize(desktopWindow: DesktopWindow): void {
-    //this is the window viewport size, so you must subtract the header and launchbar from the height.
+    //This is the window viewport size, so you must subtract the header and launchbar from the height, if not in standalone mode.
+    let height;
+    if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+      height = window.innerHeight;
+    } else {
+      height = window.innerHeight - WindowManagerService.MAXIMIZE_WINDOW_HEIGHT_OFFSET;
+    }
     desktopWindow.windowState.position = { top: 0,
                                            left: 0,
                                            width: window.innerWidth,
-                                           height: window.innerHeight
-                                           - WindowManagerService.MAXIMIZE_WINDOW_HEIGHT_OFFSET};
+                                           height: height};
   }
 
   private generateWindowId(): MVDWindowManagement.WindowId {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.html
@@ -67,7 +67,7 @@
       [style.left]="minimizeLeft"
       [ngStyle]="hasFocus() ? {'filter': buttonFilter} : {}"
       (click)="minimizeToggle()"
-      [style.display]="displayMinimize"></div>
+      *ngIf="displayMinimize"></div>
     <div class="maximize-button" 
       [style.top]="buttonTop"
       [class.active]="hasFocus()"

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -42,7 +42,7 @@ export class WindowComponent {
   public maximizeLeft: string;
   public closeLeft: string;
   private readonly logger: ZLUX.ComponentLogger = BaseLogger;
-  public displayMinimize: string;
+  public displayMinimize: boolean;
   
   @Input() set theme(newTheme: DesktopTheme) {
     this.logger.debug('Window theme set=',newTheme);
@@ -59,11 +59,11 @@ export class WindowComponent {
         this.buttonTop = '6px';
         this.textSize = '12px';
         this.textPad = '3px';
-        this.displayMinimize = "inherit";
+        this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
         if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-          this.displayMinimize = "none";
+          this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
         break;
@@ -76,11 +76,11 @@ export class WindowComponent {
         this.buttonTop = '16px';
         this.textSize = '18px';
         this.textPad = '12px';
-        this.displayMinimize = "inherit";
+        this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
         if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-          this.displayMinimize = "none";
+          this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
         break;
@@ -93,11 +93,11 @@ export class WindowComponent {
         this.buttonTop = '9px';
         this.textSize = '14px';
         this.textPad = '5px';
-        this.displayMinimize = "inherit";
+        this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
         if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-          this.displayMinimize = "none";
+          this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
     }


### PR DESCRIPTION
**How to test?**

Set 
`(window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;` 
anywhere upon virtual desktop startup, for example in
zlux-app-manager\virtual-desktop\src\app\window-manager\mvd-window-manager\launchbar\launchbar\launchbar.component.ts

To test this PR with an opened app (because the app bar will be hidden, and thus you can't open new apps) I'd recommend using https://github.com/zowe/sample-react-app/pull/30/files or any other auto-save example in the Sample Apps that uses the autosave feature to re-open itself upon Desktop refresh. I don't remember if the re-opening itself relies on auto-save or the desktop auto-save changes and a simple staging build of the Sample React App, but anyway that PR will have both

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>