### PR TITLE
Enable Desktop actions (mvd-window-manager) for single app/standalone mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Manager will be documented in this file.
 
+## `1.18.0`
+
+- Enhanced standalone/single app mode such that Desktop actions (Notifications, right click context menu, etc.) are now available
+
 ## `1.16.0`
 
 - Added the relevant chmod/chown arguments to the Zowe URI Broker to enable the changing of ownership & permissions of USS files & folders

--- a/bootstrap/src/assets/i18n/log/messages_en.json
+++ b/bootstrap/src/assets/i18n/log/messages_en.json
@@ -40,6 +40,7 @@
     "ZWED5040I":"Found some wrappers %s",
     "ZWED5041I":"ectxt=",
     "ZWED5042I":"dispatcher.invokeAction on context %s",
+    "ZWED5043I":"RESERVED: MVD standalone container requested with pluginId %s",
 
     "ZWED5000W":"RESERVED: Desktop attempted to change instanceId for iframe instance=%s, message=%s",
     "ZWED5001W":"pluginWSUri not implemented yet!",

--- a/bootstrap/src/bootstrap/bootstrap-manager.ts
+++ b/bootstrap/src/bootstrap/bootstrap-manager.ts
@@ -21,11 +21,11 @@ declare var window: { ZoweZLUX: typeof ZoweZLUXResources };
 export class BootstrapManager {
   private static bootstrapPerformed = false;
 
-  private static bootstrapGlobalResources(simpleContainerRequested: boolean) {
+  private static bootstrapGlobalResources(standaloneContainerRequested: boolean) {
     const uriBroker = (window as any)['GIZA_ENVIRONMENT'];
-    console.log("ZWED5004I - bootstrapGlobalResources simpleContainerRequested flag value: ", simpleContainerRequested);
+    console.log("ZWED5004I - bootstrapGlobalResources standaloneContainerRequested flag value: ", standaloneContainerRequested);
     console.log("ZWED5005I - bootstrapGlobalResources GIZA_ENVIRONMENT value: ", uriBroker);
-    if (simpleContainerRequested && uriBroker.toUpperCase() === 'DSM') {
+    if (standaloneContainerRequested && uriBroker.toUpperCase() === 'DSM') {
       window.ZoweZLUX = DSMResources;
     } else {
       window.ZoweZLUX = ZoweZLUXResources;
@@ -56,9 +56,9 @@ export class BootstrapManager {
   }
 
   static bootstrapDesktop(injectionCallback: (plugin: ZLUX.Plugin) => Promise<void>) {
-    const simpleContainerRequested = (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'];
+    const standaloneContainerRequested = (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'];
 
-    BootstrapManager.bootstrapGlobalResources(simpleContainerRequested);
+    BootstrapManager.bootstrapGlobalResources(standaloneContainerRequested);
 
     PluginManager.loadPlugins(ZLUX.PluginType.Desktop).then(desktops => {
       console.log(`ZWED5007I - ${desktops.length} desktops available`);

--- a/bootstrap/src/bootstrap/bootstrap-manager.ts
+++ b/bootstrap/src/bootstrap/bootstrap-manager.ts
@@ -15,17 +15,14 @@ import { PluginManager } from 'zlux-base/plugin-manager/plugin-manager'
 import { ZoweZLUXResources } from './rocket-mvd-resources'
 import { DSMResources } from './dsm-resources'
 
-
-declare var window: { ZoweZLUX: typeof ZoweZLUXResources };
-
 export class BootstrapManager {
   private static bootstrapPerformed = false;
 
   private static bootstrapGlobalResources(standaloneContainerRequested: boolean) {
-    const uriBroker = (window as any)['GIZA_ENVIRONMENT'];
+    const uriBroker = window['GIZA_ENVIRONMENT'];
     console.log("ZWED5004I - bootstrapGlobalResources standaloneContainerRequested flag value: ", standaloneContainerRequested);
     console.log("ZWED5005I - bootstrapGlobalResources GIZA_ENVIRONMENT value: ", uriBroker);
-    if (standaloneContainerRequested && uriBroker.toUpperCase() === 'DSM') {
+    if (standaloneContainerRequested && uriBroker && uriBroker.toUpperCase() === 'DSM') {
       window.ZoweZLUX = DSMResources;
     } else {
       window.ZoweZLUX = ZoweZLUXResources;
@@ -56,7 +53,7 @@ export class BootstrapManager {
   }
 
   static bootstrapDesktop(injectionCallback: (plugin: ZLUX.Plugin) => Promise<void>) {
-    const standaloneContainerRequested = (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'];
+    const standaloneContainerRequested = window['GIZA_SIMPLE_CONTAINER_REQUESTED'] || false;
 
     BootstrapManager.bootstrapGlobalResources(standaloneContainerRequested);
 

--- a/bootstrap/src/bootstrap/dsm-resources.ts
+++ b/bootstrap/src/bootstrap/dsm-resources.ts
@@ -19,8 +19,6 @@ import { ZoweNotificationManager } from 'zlux-base/notification-manager/notifica
 import { SimpleGlobalization } from '../i18n/simple-globalization'
 // import { VirtualDesktopAdapter } from '../abstract-virtual-desktop/virtual-desktop-adapter'
 
-declare var window: { ZoweZLUX: typeof DSMResources };
-window; /* Suppress TS error */
 let logger = new Logger();
 logger.addDestination(logger.makeDefaultDestination(true,true,true));
 

--- a/bootstrap/src/bootstrap/rocket-mvd-resources.ts
+++ b/bootstrap/src/bootstrap/rocket-mvd-resources.ts
@@ -19,11 +19,7 @@ import { ZoweNotificationManager } from 'zlux-base/notification-manager/notifica
 import { SimpleGlobalization } from '../i18n/simple-globalization'
 // import { VirtualDesktopAdapter } from '../abstract-virtual-desktop/virtual-desktop-adapter'
 
-declare var window: { ZoweZLUX: typeof ZoweZLUXResources,
-                      COM_RS_COMMON_LOGGER: Logger};
-window; /* Suppress TS error */
-
-// This is ithe core logger
+// This is the core logger
 let logger = new Logger();
 logger.addDestination(logger.makeDefaultDestination(true,true,true,true,true));
 window.COM_RS_COMMON_LOGGER = logger;

--- a/bootstrap/src/bootstrap/rocket-mvd-resources.ts
+++ b/bootstrap/src/bootstrap/rocket-mvd-resources.ts
@@ -40,6 +40,7 @@ fetch('/ZLUX/plugins/org.zowe.zlux.bootstrap/web/assets/i18n/log/messages_en.jso
 
   PluginManager.logger = bootstrapLogger;
 
+// TODO: Possible duplicate in index.d.ts in zlux-platform ???
 export class ZoweZLUXResources {
   static pluginManager = PluginManager
   static uriBroker:ZLUX.UriBroker = new MvdUri();

--- a/bootstrap/src/main.ts
+++ b/bootstrap/src/main.ts
@@ -41,11 +41,11 @@ function processApp2AppArgs(url?: string): void {
         pluginId = value;
         break;
       case "showLogin":
-        if (typeof value == "string") {
-          window['ZOWE_SWM_SHOW_LOGIN'] = parseInt(value);
-        } else {
-          window['ZOWE_SWM_SHOW_LOGIN'] = value;
-        }
+          if (value == "true") {
+            window['ZOWE_SWM_SHOW_LOGIN'] = true;
+          } else {
+            window['ZOWE_SWM_SHOW_LOGIN'] = false;
+          }
         break;
       case "windowManager":
         windowManager = value;

--- a/bootstrap/src/main.ts
+++ b/bootstrap/src/main.ts
@@ -15,10 +15,10 @@ export { BootstrapManager } from './bootstrap/bootstrap-manager'
 processApp2AppArgs();
 
 try {
-  const simpleContainerRequested = (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'];
-  const uriBroker = (window as any)['GIZA_ENVIRONMENT'];
+  const simpleContainerRequested = window['GIZA_SIMPLE_CONTAINER_REQUESTED'];
+  const uriBroker = window['GIZA_ENVIRONMENT'];
 
-  if (!simpleContainerRequested || uriBroker.toUpperCase() === 'MVD') {
+  if (!simpleContainerRequested || (uriBroker && uriBroker.toUpperCase() === 'MVD')) {
     BootstrapManager.bootstrapDesktopAndInject();
   }
 } catch (error) {
@@ -29,19 +29,23 @@ try {
 /* Minor code duplication of StartURLManager, but Typescript gives compile problems we can't easily ignore when we import it */
 function processApp2AppArgs(url?: string): void {
   const queryString = url || location.search.substr(1);
-  let pluginId, windowManager;
+  let pluginId, windowManager: any;
 
   queryString.split('&').forEach(part => {
     const [key, value] = part.split('=').map(v => decodeURIComponent(v));
     switch (key) {
       case "pluginId":
-        (window as any)['GIZA_PLUGIN_TO_BE_LOADED'] = value;
-        (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
-        (window as any)['GIZA_ENVIRONMENT'] = 'MVD';
+        window['GIZA_PLUGIN_TO_BE_LOADED'] = value;
+        window['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
+        window['GIZA_ENVIRONMENT'] = 'MVD';
         pluginId = value;
         break;
       case "showLogin":
-        (window as any)['ZOWE_SWM_SHOW_LOGIN'] = value;
+        if (typeof value == "string") {
+          window['ZOWE_SWM_SHOW_LOGIN'] = parseInt(value);
+        } else {
+          window['ZOWE_SWM_SHOW_LOGIN'] = value;
+        }
         break;
       case "windowManager":
         windowManager = value;
@@ -49,8 +53,8 @@ function processApp2AppArgs(url?: string): void {
     }
   });
 
-  if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-    if (windowManager == 'MVD' || windowManager == 'mvd') {
+  if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+    if (windowManager && windowManager.toUpperCase() === 'MVD') {
       console.log(`ZWED5043I - MVD standalone container requested with pluginId ${pluginId}`);
     } else {
       console.log(`ZWED5003I - Simple container requested with pluginId ${pluginId}`);

--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -49,7 +49,7 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
     this.applicationInstances = new Map();
     this.knownLoggerMessageChecks = [];
     this.nextInstanceId = 0;
-    (window as any).ZoweZLUX.dispatcher.setLaunchHandler((zluxPlugin:ZLUX.Plugin, metadata: any) => {
+    window.ZoweZLUX.dispatcher.setLaunchHandler((zluxPlugin:ZLUX.Plugin, metadata: any) => {
       return this.pluginManager.findPluginDefinition(zluxPlugin.getIdentifier()).then(plugin => {
         if (plugin == null) {
           throw new Error('ZWED5146E - Unknown plugin in launch handler '+zluxPlugin);
@@ -58,7 +58,7 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
       });
     });
     
-    (window as any).ZoweZLUX.dispatcher.setPostMessageHandler( (instanceId:MVDHosting.InstanceId, message:any ) => {
+    window.ZoweZLUX.dispatcher.setPostMessageHandler( (instanceId:MVDHosting.InstanceId, message:any ) => {
        let applicationInstance:ApplicationInstance|undefined = this.applicationInstances.get(instanceId);
        if (applicationInstance){
          let theIframe:HTMLElement|null = document.getElementById(`${IFRAME_NAME_PREFIX}${instanceId}`);

--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -272,6 +272,9 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
   }
 
   spawnApplication(plugin: DesktopPluginDefinitionImpl, launchMetadata: any): Promise<MVDHosting.InstanceId> {
+    if (launchMetadata && launchMetadata.data && launchMetadata.data.isFirstFullscreenApp) {
+      return this.spawnApplicationInFullscreenStandalone(plugin, launchMetadata);
+    }
     // Create fresh application instance
     //console.trace("AppManager.service spawnApp called with plugin (type DPD) = "+JSON.stringify(plugin));
     const applicationInstance = this.createApplicationInstance(plugin);
@@ -279,6 +282,20 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
     // Generate initial instance window
     const windowManager: MVDWindowManagement.WindowManagerServiceInterface = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
     const windowId = windowManager.createWindow(plugin);
+    const viewportId = windowManager.getViewportId(windowId);
+    this.viewportManager.registerViewport(viewportId, applicationInstance.instanceId);
+
+    return this.spawnApplicationIntoViewport(plugin, launchMetadata, applicationInstance, viewportId);
+  }
+
+  spawnApplicationInFullscreenStandalone(plugin: DesktopPluginDefinitionImpl, launchMetadata: any): Promise<MVDHosting.InstanceId> {
+    // Create fresh application instance
+    //console.trace("AppManager.service spawnApp called with plugin (type DPD) = "+JSON.stringify(plugin));
+    const applicationInstance = this.createApplicationInstance(plugin);
+
+    // Generate initial instance window
+    const windowManager: MVDWindowManagement.WindowManagerServiceInterface = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
+    const windowId = windowManager.createFullscreenStandaloneWindow(plugin);
     const viewportId = windowManager.getViewportId(windowId);
     this.viewportManager.registerViewport(viewportId, applicationInstance.instanceId);
 

--- a/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
+++ b/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
@@ -191,8 +191,20 @@ export class AuthenticationManager {
   requestLogout(): void {
     this.doLogoutInner(MVDHosting.LoginScreenChangeReason.UserLogout);
   }
+  
+  public spawnApplicationsWithNoUsername(): any {
+    window.localStorage.setItem('username', "");
+    this.username = "";
+    (ZoweZLUX.logger as any)._setBrowserUsername("");
+    this.performPostLoginActions().subscribe(
+      () => {
+        this.log.debug('ZWED5303I'); //this.log.debug('Done performing post-login actions');
+        this.loginScreenVisibilityChanged.emit(MVDHosting.LoginScreenChangeReason.UserLogin);
+      }
+    );
+  }
 
-  private performPostLoginActions(): Observable<any> {
+  private performPostLoginActions(launchAutoSaved?: boolean): Observable<any> {
     return new Observable((observer)=> {
       this.pluginManager.loadApplicationPluginDefinitions().then((pluginDefs:MVDHosting.DesktopPluginDefinition[])=> {
         let plugins = pluginDefs.map(plugin => plugin.getBasePlugin());
@@ -208,8 +220,10 @@ export class AuthenticationManager {
         observer.error(err);
       });
 
-      const windowManager: MVDWindowManagement.WindowManagerServiceInterface = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
-      windowManager.launchDesktopAutoSavedApplications();
+      if (launchAutoSaved !== false) {
+        const windowManager: MVDWindowManagement.WindowManagerServiceInterface = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
+        windowManager.launchDesktopAutoSavedApplications();
+      }
     });
   }
 

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.html
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.html
@@ -67,7 +67,7 @@
 </div>
 
 <!-- sometimes we may not be able to tell if the user is idle or not, so ask them directly with a popup -->
-<zlux-popup-manager>
+<zlux-popup-manager *ngIf="enableSessionTimeoutPopup">
 </zlux-popup-manager>
 
 <!--

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.html
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.html
@@ -67,7 +67,7 @@
 </div>
 
 <!-- sometimes we may not be able to tell if the user is idle or not, so ask them directly with a popup -->
-<zlux-popup-manager *ngIf="enableSessionTimeoutPopup">
+<zlux-popup-manager *ngIf="enableExpirationPrompt">
 </zlux-popup-manager>
 
 <!--

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -47,7 +47,7 @@ export class LoginComponent implements OnInit {
   private passwordServices: Set<string>;
   private themeManager: any;
   public showLogin: boolean;
-  public enableSessionTimeoutPopup: boolean;
+  public enableExpirationPrompt: boolean;
 
   constructor(
     private authenticationService: AuthenticationManager,
@@ -69,7 +69,7 @@ export class LoginComponent implements OnInit {
     this.errorMessage = '';
     this.expiredPassword = false;
     this.passwordServices = new Set<string>();
-    this.enableSessionTimeoutPopup = true;
+    this.enableExpirationPrompt = true;
     this.renewSession = this.renewSession.bind(this);
     this.isIdle = this.isIdle.bind(this);
     this.authenticationService.loginScreenVisibilityChanged.subscribe((eventReason: MVDHosting.LoginScreenChangeReason) => {
@@ -112,6 +112,7 @@ export class LoginComponent implements OnInit {
       } else {
         this.logger.info('ZWED5048I'); /*this.logger.info('Near session expiration. No activity detected, prompting to renew session');*/
         this.spawnExpirationPrompt(e.expirationInMS);
+        this.enableExpirationPrompt = true;
       }
     });
     this.showLogin = (window as any).ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
@@ -183,7 +184,7 @@ export class LoginComponent implements OnInit {
         this.isLoading = false;
         if (!this.showLogin && !!(window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
           this.authenticationService.spawnApplicationsWithNoUsername();
-          this.enableSessionTimeoutPopup = false;
+          this.enableExpirationPrompt = false;
           this.needLogin = false;
         } else {
           this.needLogin = true;

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -115,7 +115,7 @@ export class LoginComponent implements OnInit {
         this.enableExpirationPrompt = true;
       }
     });
-    this.showLogin = window.ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
+    this.showLogin = window.ZOWE_SWM_SHOW_LOGIN == true ? true : false;
   }
 
   private isIdle(): boolean {

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -115,7 +115,7 @@ export class LoginComponent implements OnInit {
         this.enableExpirationPrompt = true;
       }
     });
-    this.showLogin = (window as any).ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
+    this.showLogin = window.ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
   }
 
   private isIdle(): boolean {
@@ -182,7 +182,7 @@ export class LoginComponent implements OnInit {
           }
         }
         this.isLoading = false;
-        if (!this.showLogin && !!(window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (!this.showLogin && window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
           this.authenticationService.spawnApplicationsWithNoUsername();
           this.enableExpirationPrompt = false;
           this.needLogin = false;

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -46,6 +46,8 @@ export class LoginComponent implements OnInit {
   expiredPassword: boolean;
   private passwordServices: Set<string>;
   private themeManager: any;
+  public showLogin: boolean;
+  public enableSessionTimeoutPopup: boolean;
 
   constructor(
     private authenticationService: AuthenticationManager,
@@ -67,6 +69,7 @@ export class LoginComponent implements OnInit {
     this.errorMessage = '';
     this.expiredPassword = false;
     this.passwordServices = new Set<string>();
+    this.enableSessionTimeoutPopup = true;
     this.renewSession = this.renewSession.bind(this);
     this.isIdle = this.isIdle.bind(this);
     this.authenticationService.loginScreenVisibilityChanged.subscribe((eventReason: MVDHosting.LoginScreenChangeReason) => {
@@ -111,6 +114,7 @@ export class LoginComponent implements OnInit {
         this.spawnExpirationPrompt(e.expirationInMS);
       }
     });
+    this.showLogin = (window as any).ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
   }
 
   private isIdle(): boolean {
@@ -177,7 +181,13 @@ export class LoginComponent implements OnInit {
           }
         }
         this.isLoading = false;
-        this.needLogin = true;
+        if (!this.showLogin && !!(window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+          this.authenticationService.spawnApplicationsWithNoUsername();
+          this.enableSessionTimeoutPopup = false;
+          this.needLogin = false;
+        } else {
+          this.needLogin = true;
+        }
       });
   }
 

--- a/virtual-desktop/src/app/i18n/language-locale.service.ts
+++ b/virtual-desktop/src/app/i18n/language-locale.service.ts
@@ -50,7 +50,7 @@ export class LanguageLocaleService {
   }
 
   makeLocaleURI(localeId: string): string {
-    const baseURI: string = (window as any).ZoweZLUX.uriBroker.desktopRootUri();
+    const baseURI: string = window.ZoweZLUX.uriBroker.desktopRootUri();
     return `${baseURI}locales/${localeId}`;
   }
 

--- a/virtual-desktop/src/app/i18n/language-locale.service.ts
+++ b/virtual-desktop/src/app/i18n/language-locale.service.ts
@@ -50,7 +50,7 @@ export class LanguageLocaleService {
   }
 
   makeLocaleURI(localeId: string): string {
-    const baseURI: string = window.ZoweZLUX.uriBroker.desktopRootUri();
+    const baseURI: string = ZoweZLUX.uriBroker.desktopRootUri();
     return `${baseURI}locales/${localeId}`;
   }
 

--- a/virtual-desktop/src/app/i18n/locale-initializer.provider.ts
+++ b/virtual-desktop/src/app/i18n/locale-initializer.provider.ts
@@ -16,7 +16,7 @@ import { Observable } from 'rxjs/Rx';
 const logger: ZLUX.ComponentLogger = ZoweZLUX.logger.makeComponentLogger('org.zowe.zlux.virtual-desktop.i18n');
 
 export const localeIdFactory = (localeService: LanguageLocaleService): string => {
-  const zoweGlobal = window.ZoweZLUX;
+  const zoweGlobal = ZoweZLUX;
 
   // chicken and egg bootstrapping problem. virtual-desktop wants a particular implementation
   // of globalization that can use cookies set by the browser-preferences service of this plugin
@@ -30,7 +30,7 @@ export const localeIdFactory = (localeService: LanguageLocaleService): string =>
 
 export const localeInitializer = (localeService: LanguageLocaleService, localeId: string) => {
   return (): Promise<any> => {
-    const baseURI: string = window.ZoweZLUX.uriBroker.desktopRootUri();
+    const baseURI: string = ZoweZLUX.uriBroker.desktopRootUri();
     if (localeService.isConfiguredForDefaultLanguage()) {
       return Promise.resolve();
     }

--- a/virtual-desktop/src/app/i18n/locale-initializer.provider.ts
+++ b/virtual-desktop/src/app/i18n/locale-initializer.provider.ts
@@ -16,7 +16,7 @@ import { Observable } from 'rxjs/Rx';
 const logger: ZLUX.ComponentLogger = ZoweZLUX.logger.makeComponentLogger('org.zowe.zlux.virtual-desktop.i18n');
 
 export const localeIdFactory = (localeService: LanguageLocaleService): string => {
-  const zoweGlobal = (window as any).ZoweZLUX;
+  const zoweGlobal = window.ZoweZLUX;
 
   // chicken and egg bootstrapping problem. virtual-desktop wants a particular implementation
   // of globalization that can use cookies set by the browser-preferences service of this plugin
@@ -30,7 +30,7 @@ export const localeIdFactory = (localeService: LanguageLocaleService): string =>
 
 export const localeInitializer = (localeService: LanguageLocaleService, localeId: string) => {
   return (): Promise<any> => {
-    const baseURI: string = (window as any).ZoweZLUX.uriBroker.desktopRootUri();
+    const baseURI: string = window.ZoweZLUX.uriBroker.desktopRootUri();
     if (localeService.isConfiguredForDefaultLanguage()) {
       return Promise.resolve();
     }

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -63,7 +63,7 @@ export class IFramePluginFactory extends PluginFactory {
     if (startingPage.startsWith('http://') || startingPage.startsWith('https://')) {
       startingPageUri = startingPage;
     } else {
-      startingPageUri = window.ZoweZLUX.uriBroker.pluginResourceUri(basePlugin, startingPage);
+      startingPageUri = ZoweZLUX.uriBroker.pluginResourceUri(basePlugin, startingPage);
     }
     this.logger.debug('ZWED5308I', startingPageUri); //this.logger.debug('iframe startingPageUri', startingPageUri);
     const safeStartingPageUri: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(startingPageUri);

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -63,7 +63,7 @@ export class IFramePluginFactory extends PluginFactory {
     if (startingPage.startsWith('http://') || startingPage.startsWith('https://')) {
       startingPageUri = startingPage;
     } else {
-      startingPageUri = (window as any).ZoweZLUX.uriBroker.pluginResourceUri(basePlugin, startingPage);
+      startingPageUri = window.ZoweZLUX.uriBroker.pluginResourceUri(basePlugin, startingPage);
     }
     this.logger.debug('ZWED5308I', startingPageUri); //this.logger.debug('iframe startingPageUri', startingPageUri);
     const safeStartingPageUri: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(startingPageUri);

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin.component.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin.component.ts
@@ -257,7 +257,7 @@ export class IFramePluginComponent {
     }
     fn = (this.getAttrib(Object.assign({}, ZoweZLUX), split.join('.')) as Function);
     if(typeof fn === 'function'){
-      fn = fn.bind(window.ZoweZLUX[split[0]]);
+      fn = fn.bind((ZoweZLUX as any)[split[0]]);
       if(args.length === 0){
         fnRet = fn();
       } else {

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin.component.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin.component.ts
@@ -257,7 +257,7 @@ export class IFramePluginComponent {
     }
     fn = (this.getAttrib(Object.assign({}, ZoweZLUX), split.join('.')) as Function);
     if(typeof fn === 'function'){
-      fn = fn.bind((window as any).ZoweZLUX[split[0]]);
+      fn = fn.bind(window.ZoweZLUX[split[0]]);
       if(args.length === 0){
         fnRet = fn();
       } else {

--- a/virtual-desktop/src/app/plugin-manager/shared/desktop-plugin-definition.ts
+++ b/virtual-desktop/src/app/plugin-manager/shared/desktop-plugin-definition.ts
@@ -86,7 +86,7 @@ export class DesktopPluginDefinitionImpl implements MVDHosting.DesktopPluginDefi
   }
 
   get image(): string | null {
-    const uriBroker = window.ZoweZLUX.uriBroker;
+    const uriBroker = ZoweZLUX.uriBroker;
     if (!this.hasWebContent){
         return null;
     }

--- a/virtual-desktop/src/app/plugin-manager/shared/desktop-plugin-definition.ts
+++ b/virtual-desktop/src/app/plugin-manager/shared/desktop-plugin-definition.ts
@@ -86,8 +86,7 @@ export class DesktopPluginDefinitionImpl implements MVDHosting.DesktopPluginDefi
   }
 
   get image(): string | null {
-    // TODO: clean this up with .d.ts
-    const uriBroker = (window as any).ZoweZLUX.uriBroker;
+    const uriBroker = window.ZoweZLUX.uriBroker;
     if (!this.hasWebContent){
         return null;
     }

--- a/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
@@ -26,33 +26,43 @@ export class App2AppArgsParser {
   parse(app2appArray: string[]): App2AppArgs {
     let app2appKey = app2appArray[0];
     let app2app = app2appArray[1];
-    let pluginId, actionType, actionMode, formatter, contextData;
+    let pluginId, actionType, actionMode, formatter, contextData, contextZlux;
+    this.startIndex = 0;
+    this.length = app2app.length;
+    this.data = app2app;
+
     switch(app2appKey) {
-      case "pluginId": // Open In New Browser Tab
-        pluginId = app2app;
+      case "pluginId": // Assuming pluginId=xxx.xxx.xxx:formatter:{"xxx":"xxx" ...}
+        pluginId = this.getPart();
+        if (!pluginId) { // If pluginId=xxx.xx.xxx (no app2app data)
+          pluginId = app2app;
+          formatter = "data";
+          contextData = "{}";
+        } else {
+          formatter = this.getPart();
+          contextData = this.getLastPart();
+        }
         actionType = "launch";
         actionMode = "create";
-        formatter = "data";
-        contextData = '{"isFirstFullscreenApp":"' + this.isFirstFullscreenApp + '"}';
+        contextZlux = JSON.stringify({isFirstFullscreenApp: this.isFirstFullscreenApp});
         this.isFirstFullscreenApp = false;
         break;
-      default: // Assume normal app2app
-        this.startIndex = 0;
-        this.length = app2app.length;
-        this.data = app2app;
+      default: // Assume normal app2app, app2app=xxx.xxx.xxx:type:mode:formatter:{contextdata ...}
         pluginId = this.getPart();
         actionType = this.getPart();
         actionMode = this.getPart();
         formatter = this.getPart();
         contextData = this.getLastPart();
+        contextZlux = "{}";
     }
     return {
       pluginId,
       actionType,
       actionMode,
       formatter,
-      contextData
-    };
+      contextData,
+      contextZlux
+    }
   }
 
   private getPart(): string {

--- a/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
@@ -22,21 +22,34 @@ export class App2AppArgsParser {
 
   }
 
-  parse(app2app: string): App2AppArgs {
-    this.startIndex = 0;
-    this.length = app2app.length;
-    this.data = app2app;
-    const pluginId = this.getPart();
-    const actionType = this.getPart();
-    const actionMode = this.getPart();
-    const formatter = this.getPart();
-    const contextData = this.getLastPart();
+  parse(app2appArray: string[]): App2AppArgs {
+    let app2appKey = app2appArray[0];
+    let app2app = app2appArray[1];
+    let pluginId, actionType, actionMode, formatter, contextData;
+    switch(app2appKey) {
+      case "pluginId": // Open In New Browser Tab
+        pluginId = app2app;
+        actionType = "launch";
+        actionMode = "create";
+        formatter = "data";
+        contextData = "{}"; // TODO: Populate with "Open In New Browser Tab..." additional params?
+        break;
+      default: // Assume normal app2app
+        this.startIndex = 0;
+        this.length = app2app.length;
+        this.data = app2app;
+        pluginId = this.getPart();
+        actionType = this.getPart();
+        actionMode = this.getPart();
+        formatter = this.getPart();
+        contextData = this.getLastPart();
+    }
     return {
       pluginId,
       actionType,
       actionMode,
       formatter,
-      contextData,
+      contextData
     };
   }
 

--- a/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
@@ -17,9 +17,10 @@ export class App2AppArgsParser {
   private startIndex: number;
   private length: number;
   private data: string;
+  private isFirstFullscreenApp: boolean;
 
   constructor() {
-
+    this.isFirstFullscreenApp = true;
   }
 
   parse(app2appArray: string[]): App2AppArgs {
@@ -32,7 +33,8 @@ export class App2AppArgsParser {
         actionType = "launch";
         actionMode = "create";
         formatter = "data";
-        contextData = "{}"; // TODO: Populate with "Open In New Browser Tab..." additional params?
+        contextData = '{"isFirstFullscreenApp":"' + this.isFirstFullscreenApp + '"}';
+        this.isFirstFullscreenApp = false;
         break;
       default: // Assume normal app2app
         this.startIndex = 0;

--- a/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/app2app-args-parser.service.ts
@@ -20,7 +20,7 @@ export class App2AppArgsParser {
   private isFirstFullscreenApp: boolean;
 
   constructor() {
-    this.isFirstFullscreenApp = true;
+    this.isFirstFullscreenApp = true; // Variable used to keep track of if plugin in desktop URL is for standalone mode
   }
 
   parse(app2appArray: string[]): App2AppArgs {

--- a/virtual-desktop/src/app/start-url-manager/app2app-args.ts
+++ b/virtual-desktop/src/app/start-url-manager/app2app-args.ts
@@ -14,6 +14,7 @@ export interface App2AppArgs {
   actionMode: string,
   formatter: string;
   contextData: string;
+  contextZlux: string;
 }
 
 

--- a/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
@@ -105,14 +105,15 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
 
   private getAllApp2AppArgsFromURL(): App2AppArgs[] {
     const queryString = location.search.substr(1);
-    const app2appValues: string[] = [];
+    const app2appArray: string[][] = [];
     queryString.split('&').forEach(part => {
       const [key, value] = part.split('=').map(v => decodeURIComponent(v));
-      if (key === 'app2app') {
-        app2appValues.push(value);
+      // TODO: Check against a list of known URI arg params instead of hardcode
+      if (key === 'app2app' || key === 'pluginId') {
+        app2appArray.push([key, value]);
       }
     });
-    return app2appValues.map(value => this.parser.parse(value));
+    return app2appArray.map(value => this.parser.parse(value));
   }
 
   private registerTestAction(): void {

--- a/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
@@ -113,11 +113,11 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
   }
 
   private getAllApp2AppArgsFromURL(): App2AppArgs[] {
-    const app2appArray: string[][] = this.getApp2AppArgsArray();
+    const app2appArray: string[][] = StartURLManager.getApp2AppArgsArray();
     return app2appArray.map(value => this.parser.parse(value));
   }
 
-  public getApp2AppArgsArray(url?: string): string[][] {
+  public static getApp2AppArgsArray(url?: string): string[][] {
     const queryString = url || location.search.substr(1);
     const app2appArray: string[][] = [];
     queryString.split('&').forEach(part => {

--- a/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
@@ -89,6 +89,7 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
     const type = args.actionType === 'launch' ? ActionType.Launch : ActionType.Message;
     const mode = args.actionMode === 'create' ? ActionTargetMode.PluginCreate : ActionTargetMode.System;
     const contextData: any = JSON.parse(args.contextData);
+    let contextZlux = args.contextZlux ? JSON.parse(args.contextZlux) : undefined;
     let action: ZLUX.Action;
     let argumentData: any;
     if (args.formatter === 'data') {
@@ -96,7 +97,7 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
       const actionId = 'org.zowe.zlux.url.launch';
       const argumentFormatter = { data: { op: 'deref', source: 'event', path: ['data'] } };
       action = dispatcher.makeAction(actionId, actionTitle, mode, type, args.pluginId, argumentFormatter);
-      argumentData = { data: contextData };
+      argumentData = contextZlux ? { data: contextData, zlux: contextZlux } : { data: contextData };
     } else {
       const abstractAction = dispatcher.getAbstractActionById(args.formatter);
       action = <ZLUX.Action>{

--- a/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
@@ -102,15 +102,7 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
       argumentData = contextData;
     }
     dispatcher.invokeAction(action, argumentData)
-    .then((yeet: any) => {
-      if (contextData && contextData.isFirstFullscreenApp && args.pluginId) {
-        // Importing WindowManagerService in the constructor has timing issues
-        const windowManager: any = this.injector.get(MVDWindowManagement.Tokens.WindowManagerToken);
-        // We are going to maximize the first pluginId app to make it full screen
-        const windowId = windowManager.runningPluginMap.get(args.pluginId)[0];
-        windowManager.maximize(windowId);
-      }
-    })
+    .then(() => {})
     .catch((e:any) => this.handleInvokeActionError(e));
   }
 

--- a/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
@@ -8,10 +8,17 @@
   Copyright Contributors to the Zowe Project.
 */
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { BaseLogger } from 'virtual-desktop-logger';
 import { App2AppArgs } from './app2app-args';
 import { App2AppArgsParser } from './app2app-args-parser.service';
+
+const ZOWE_URL_ARGS = [
+  "app2app",
+  "pluginId",
+  "windowManager",
+  "showLogin"
+]
 
 @Injectable()
 export class StartURLManager implements MVDHosting.LoginActionInterface {
@@ -19,8 +26,7 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
   private readonly logger: ZLUX.ComponentLogger = BaseLogger;
 
   constructor(
-    public parser: App2AppArgsParser,
-    public injector: Injector
+    public parser: App2AppArgsParser
   ) {
     this.registerTestAction();
   }
@@ -116,8 +122,7 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
     const app2appArray: string[][] = [];
     queryString.split('&').forEach(part => {
       const [key, value] = part.split('=').map(v => decodeURIComponent(v));
-      // TODO: Check against a list of known URI arg params instead of hardcode
-      if (key === 'app2app' || key === 'pluginId' || key === 'windowManager') {
+      if (ZOWE_URL_ARGS.includes(key)) {
         app2appArray.push([key, value]);
       }
     });

--- a/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
+++ b/virtual-desktop/src/app/start-url-manager/start-url-manager.service.ts
@@ -107,16 +107,21 @@ export class StartURLManager implements MVDHosting.LoginActionInterface {
   }
 
   private getAllApp2AppArgsFromURL(): App2AppArgs[] {
-    const queryString = location.search.substr(1);
+    const app2appArray: string[][] = this.getApp2AppArgsArray();
+    return app2appArray.map(value => this.parser.parse(value));
+  }
+
+  public getApp2AppArgsArray(url?: string): string[][] {
+    const queryString = url || location.search.substr(1);
     const app2appArray: string[][] = [];
     queryString.split('&').forEach(part => {
       const [key, value] = part.split('=').map(v => decodeURIComponent(v));
       // TODO: Check against a list of known URI arg params instead of hardcode
-      if (key === 'app2app' || key === 'pluginId') {
+      if (key === 'app2app' || key === 'pluginId' || key === 'windowManager') {
         app2appArray.push([key, value]);
       }
     });
-    return app2appArray.map(value => this.parser.parse(value));
+    return app2appArray;
   }
 
   private registerTestAction(): void {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
@@ -146,7 +146,7 @@ export class LaunchbarMenuComponent implements MVDHosting.LoginActionInterface{
     this.appKeyboard.keyUpEvent
       .subscribe((event:KeyboardEvent) => {
         // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
-        if (event.which === KeyCode.KEY_M && !(window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (event.which === KeyCode.KEY_M && !window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
           this.activeToggle();
         }
     });

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.html
@@ -15,7 +15,7 @@
   [style.height]="barSize"
   (mouseup)="onMouseUpContainer($event)" 
   [class.active]="isActive"
-  *ngIf="displayAppBar">
+  [style.display]="displayAppBar">
   <rs-com-launchbar-menu [menuItems]="allItems" [theme]="_theme" (itemClicked)="menuItemClicked($event)"  (refreshClicked)="getNewItems()"></rs-com-launchbar-menu>
   
   <div class="applist row" 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -77,7 +77,7 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
     }
 
     // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
-    if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+    if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
       this.displayAppBar = "none";
     } else {
       this.displayAppBar = "inherit";

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -49,7 +49,6 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
   public _theme: DesktopTheme;
 
   @Input() set theme(newTheme: DesktopTheme) {
-    (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
     this.logger.info('Launchbar theme set=',newTheme);
     // Used to update the emitter service to sync up personalization panel with loaded theme color upon startup
     this.themeService.mainColor = newTheme.color.launchbarMenuColor;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -49,6 +49,7 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
   public _theme: DesktopTheme;
 
   @Input() set theme(newTheme: DesktopTheme) {
+    (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
     this.logger.info('Launchbar theme set=',newTheme);
     // Used to update the emitter service to sync up personalization panel with loaded theme color upon startup
     this.themeService.mainColor = newTheme.color.launchbarMenuColor;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -43,7 +43,7 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
 
   //Always 6+icon size, due to need for space for padding and such
   public barSize: string;
-  public displayAppBar: boolean;
+  public displayAppBar: string;
   public applistMargin: string;
   public applistPadding: string;
   public _theme: DesktopTheme;
@@ -78,9 +78,9 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
 
     // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
     if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-      this.displayAppBar = false;
+      this.displayAppBar = "none";
     } else {
-      this.displayAppBar = true;
+      this.displayAppBar = "inherit";
     }
   }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
@@ -73,9 +73,9 @@ function openStandalone(item: LaunchbarItem): void {
   //future TODO: initialize cross-window app2app communication??
   if (pluginType === 'iframe' && !(item.plugin.standaloneUseFramework)) {
     // Still allows IFrames to comprehend URL parameters if address is copy/pasted later. Should not break any app2app possibilities
-    window.open(`${location.origin}${window.ZoweZLUX.uriBroker.pluginResourceUri(item.plugin, item.plugin.getBasePlugin().getWebContent().startingPage)}`);
+    window.open(`${location.origin}${ZoweZLUX.uriBroker.pluginResourceUri(item.plugin.getBasePlugin(), item.plugin.getBasePlugin().getWebContent().startingPage)}`);
   } else {
-    window.open(`${location.href}?pluginId=${item.plugin.basePlugin.getIdentifier()}&showLogin=1`);
+    window.open(`${location.href}?pluginId=${item.plugin.basePlugin.getIdentifier()}&showLogin=true`);
   }
 }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
@@ -73,7 +73,7 @@ function openStandalone(item: LaunchbarItem): void {
   //future TODO: initialize cross-window app2app communication??
   if (pluginType === 'iframe' && !(item.plugin.standaloneUseFramework)) {
     // Still allows IFrames to comprehend URL parameters if address is copy/pasted later. Should not break any app2app possibilities
-    window.open(`${location.origin}${(window as any).ZoweZLUX.uriBroker.pluginResourceUri(item.plugin, item.plugin.getBasePlugin().getWebContent().startingPage)}`);
+    window.open(`${location.origin}${window.ZoweZLUX.uriBroker.pluginResourceUri(item.plugin, item.plugin.getBasePlugin().getWebContent().startingPage)}`);
   } else {
     window.open(`${location.href}?pluginId=${item.plugin.basePlugin.getIdentifier()}&showLogin=1`);
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/desktop-window-state.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/desktop-window-state.ts
@@ -56,7 +56,7 @@ export class DesktopWindowState {
     this.setStateType(DesktopWindowStateType.Maximized);
   }
 
-  maximizeFullscreen(): void {
+  _maximizeFullscreen(): void {
     this._normalPosition = this.position;
     this.setStateType(DesktopWindowStateType.MaximizedFullscreen);
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/desktop-window-state.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/desktop-window-state.ts
@@ -17,7 +17,8 @@ import { WindowPosition } from './window-position';
 export enum DesktopWindowStateType {
   Minimized,
   Maximized,
-  Normal
+  Normal,
+  MaximizedFullscreen
 }
 
 export class DesktopWindowState {
@@ -53,6 +54,11 @@ export class DesktopWindowState {
   maximize(): void {
     this._normalPosition = this.position;
     this.setStateType(DesktopWindowStateType.Maximized);
+  }
+
+  maximizeFullscreen(): void {
+    this._normalPosition = this.position;
+    this.setStateType(DesktopWindowStateType.MaximizedFullscreen);
   }
 
   minimize(): void {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/desktop-window.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/desktop-window.ts
@@ -32,6 +32,7 @@ export class DesktopWindow {
   private childViewports: Array<MVDHosting.ViewportId>;
   public readonly plugin: ZLUX.Plugin;
   viewportId: MVDHosting.ViewportId; //primary, if children exist
+  public isFullscreenStandalone: boolean;
 
   closeHandler: (() => Promise<void>) | null; //DEPRECATED 1.0.1, use viewport close handler instead of window
   
@@ -81,6 +82,7 @@ export class DesktopWindow {
 
       lastPosition = state;
     });
+    this.isFullscreenStandalone = false;
   }
 
   get windowTitle(): string {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -595,7 +595,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     /* Default window actions */
     this.setWindowTitle(windowId, pluginImpl.defaultWindowTitle);
     this.requestWindowFocus(windowId);
-    this.maximizeFullscreen(windowId);
+    this._maximizeFullscreen(windowId);
 
     return windowId;
   }
@@ -802,13 +802,13 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     this.refreshMaximizedWindowSize(desktopWindow);
   }
 
-  maximizeFullscreen(windowId: MVDWindowManagement.WindowId): void {
+  private _maximizeFullscreen(windowId: MVDWindowManagement.WindowId): void {
     const desktopWindow = this.windowMap.get(windowId);
     if (desktopWindow == null) {
       throw new Error('ZWED5157E - Attempted to maximize null window');
     }
 
-    desktopWindow.windowState.maximizeFullscreen();
+    desktopWindow.windowState._maximizeFullscreen();
   }
 
   minimize(windowId: MVDWindowManagement.WindowId): void {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -123,7 +123,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
     });
 
     let tabHandler = (event: KeyboardEvent) => {
-      if(this.focusedWindow != null){
+      if(this.focusedWindow){
         if(event.keyCode == 9 || event.which == 9){ // tab
           let activeViewportID = this.getViewportIdFromDOM(document.activeElement);
           if(activeViewportID != Number(this.focusedWindow.viewportId)){
@@ -144,12 +144,12 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
       .subscribe((event:KeyboardEvent) => {
         if (event.which === KeyCode.DOWN_ARROW) {
           // TODO: Disable minimize hotkey once mvd-window-manager single app mode is functional. Variable subject to change.
-          if(this.focusedWindow !== null && !(window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+          if(this.focusedWindow && !window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
             this.minimizeToggle(this.focusedWindow.windowId);
           }
         }
         else if (event.which === KeyCode.UP_ARROW) {
-          if(this.focusedWindow !== null) {
+          if(this.focusedWindow) {
             this.maximizeToggle(this.focusedWindow.windowId);
           }
         }
@@ -161,7 +161,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         }
         else if (event.which === KeyCode.KEY_W) {
           // We should not be able to close a standalone mode application window
-          if(this.focusedWindow !== null && !this.focusedWindow.isFullscreenStandalone) {
+          if(this.focusedWindow && !this.focusedWindow.isFullscreenStandalone) {
             this.closeWindow(this.focusedWindow.windowId);
           }
         }
@@ -230,7 +230,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   switchWindow(zDistance:number): void {
     let windows:DesktopWindow[] = this.getAllWindows();
   
-    if(this.focusedWindow != null) {
+    if(this.focusedWindow) {
       const focusedWindowId :number = this.focusedWindow.windowId; 
       windows = windows.filter( (val: DesktopWindow ) => 
         val.windowId !== focusedWindowId
@@ -249,7 +249,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
       if(windowIds.length>0) {
         const selectIdx: number = (Math.abs(zDistance) -1) % (windows.length);
         const windowId = windowIds[selectIdx];
-        if(this.focusedWindow != null && zDistance<1) {
+        if(this.focusedWindow && zDistance<1) {
           const replaceZIndex = Math.abs(sortWindows[windowIds.length-1].windowState.zIndex)-1;
           if(replaceZIndex>0) {
             this.focusedWindow.windowState.zIndex=replaceZIndex;
@@ -273,7 +273,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private refreshMaximizedWindowSize(desktopWindow: DesktopWindow): void {
     //This is the window viewport size, so you must subtract the header and launchbar from the height, if not in standalone mode.
     let height;
-    if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+    if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
       height = window.innerHeight;
     } else {
       height = window.innerHeight - WindowManagerService.MAXIMIZE_WINDOW_HEIGHT_OFFSET;
@@ -776,7 +776,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   }
 
   windowHasFocus(window: MVDWindowManagement.WindowId): boolean {
-    if (this.focusedWindow != null) {
+    if (this.focusedWindow) {
       return this.focusedWindow.windowId === window;
     } else {
       return false;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -160,7 +160,8 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
             this.switchWindow(1);
         }
         else if (event.which === KeyCode.KEY_W) {
-          if(this.focusedWindow !== null) {
+          // We should not be able to close a standalone mode application window
+          if(this.focusedWindow !== null && !this.focusedWindow.isFullscreenStandalone) {
             this.closeWindow(this.focusedWindow.windowId);
           }
         }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -49,6 +49,7 @@ export class WindowComponent {
   private desktopHeight: number;
   private desktopWidth: number;
   private zIndex: number;
+  private launchbarHeight: number;
   
   @Input() set theme(newTheme: DesktopTheme) {
     this.logger.debug('Window theme set=',newTheme);
@@ -68,7 +69,7 @@ export class WindowComponent {
         this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
-        if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
           this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
@@ -85,7 +86,7 @@ export class WindowComponent {
         this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
-        if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
           this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
@@ -102,7 +103,7 @@ export class WindowComponent {
         this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
-        if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
           this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
@@ -154,9 +155,11 @@ export class WindowComponent {
     const position = this.getPosition();
     this.desktopHeight = document.documentElement.clientHeight;
     this.desktopWidth = document.documentElement.clientWidth;
-    this.maxHeight = 'calc(100%)';
-    this.maxWidth = 'calc(100%)';
+    this.maxHeight = '100%';
+    this.maxWidth = '100%';
     this.zIndex = this.desktopWindow.windowState.zIndex;
+    // In standalone app mode, our launchbar doesn't exist
+    this.launchbarHeight = (window.GIZA_SIMPLE_CONTAINER_REQUESTED ? 0 : WindowManagerService.LAUNCHBAR_HEIGHT);
 
     /* These 4 conditionals check if a window is out of bounds by checking if a window has been
     dragged too far out of view, in either of the 4 directions, and locks it from going further. */
@@ -167,20 +170,20 @@ export class WindowComponent {
       if (position.left + position.width - this.headerSize < 0) {
         position.left = -position.width + this.headerSize;
       }
-      if ((position.top + this.headerSize) > this.desktopHeight - WindowManagerService.LAUNCHBAR_HEIGHT) {
-        position.top = this.desktopHeight - this.headerSize - WindowManagerService.LAUNCHBAR_HEIGHT;
+      if ((position.top + this.headerSize) > this.desktopHeight - this.launchbarHeight) {
+        position.top = this.desktopHeight - this.headerSize - this.launchbarHeight;
       }
       if ((position.left + this.headerSize) > this.desktopWidth) {
         position.left = this.desktopWidth - this.headerSize;
       }
     } else {
-      this.maxHeight = 'calc(110%)';
-      this.maxWidth = 'calc(102%)';
-      position.left = 0 - SCREEN_EDGE_BORDER;
-      position.top = 0 - this.headerSize - SCREEN_EDGE_BORDER;
+      this.maxHeight = '110%';
+      this.maxWidth = '102%';
+      position.left = -1 - SCREEN_EDGE_BORDER;
+      position.top = -1 - this.headerSize - SCREEN_EDGE_BORDER;
       position.width = this.desktopWidth + SCREEN_EDGE_BORDER;
       position.height = this.desktopHeight + SCREEN_EDGE_BORDER;
-      this.zIndex = 1; // So any app2app apps don't get hidden if we click away back to the main fullscreen app
+      this.zIndex = 1; // So any app2app apps don't get hidden if we click back to the main fullscreen app
     }
 
     return {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -45,7 +45,6 @@ export class WindowComponent {
   public displayMinimize: boolean;
   
   @Input() set theme(newTheme: DesktopTheme) {
-    (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
     this.logger.debug('Window theme set=',newTheme);
     this.color = newTheme.color;
     //button left strategy: size*.6 or .66 between each element and sides

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -19,7 +19,7 @@ import { WindowPosition } from '../shared/window-position';
 import { BaseLogger } from '../../../shared/logger';
 import { Colors } from '../shared/colors';
 
-const SCREEN_EDGE_BORDER = 3;
+const SCREEN_EDGE_BORDER = 2;
 
 @Component({
   selector: 'rs-com-mvd-window',

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -45,6 +45,7 @@ export class WindowComponent {
   public displayMinimize: string;
   
   @Input() set theme(newTheme: DesktopTheme) {
+    (window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
     this.logger.debug('Window theme set=',newTheme);
     this.color = newTheme.color;
     //button left strategy: size*.6 or .66 between each element and sides

--- a/virtual-desktop/src/app/window-manager/simple-window-manager/simple-window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/simple-window-manager/simple-window-manager.service.ts
@@ -54,6 +54,10 @@ export class SimpleWindowManagerService implements MVDWindowManagement.WindowMan
     return windowId;
   }
 
+  createFullscreenStandaloneWindow(plugin: MVDHosting.DesktopPluginDefinition): MVDWindowManagement.WindowId {
+    return this.createWindow(plugin);
+  }
+
   getWindow(plugin: MVDHosting.DesktopPluginDefinition): MVDWindowManagement.WindowId | null {
     return 1;
   }

--- a/virtual-desktop/src/app/window-manager/simple-window-manager/simple.component.ts
+++ b/virtual-desktop/src/app/window-manager/simple-window-manager/simple.component.ts
@@ -29,7 +29,7 @@ export class SimpleComponent implements OnInit {
   private readonly logger: ZLUX.ComponentLogger = BaseLogger;
   viewportId: MVDHosting.ViewportId;
   private windowManager: SimpleWindowManagerService;
-  public showLogin:boolean = (window as any).ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
+  public showLogin:boolean = window.ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
   public error:string='';
 
   constructor(
@@ -51,7 +51,7 @@ export class SimpleComponent implements OnInit {
       this.contextMenuDef = menuDef;
     });
     
-    let requestedPluginID: string = (window as any)['GIZA_PLUGIN_TO_BE_LOADED'];
+    let requestedPluginID: string | undefined = window['GIZA_PLUGIN_TO_BE_LOADED'];
 
     if (!requestedPluginID) {
       let message = "Plugin ID required. Use query parameter ?pluginId";

--- a/virtual-desktop/src/app/window-manager/simple-window-manager/simple.component.ts
+++ b/virtual-desktop/src/app/window-manager/simple-window-manager/simple.component.ts
@@ -29,7 +29,7 @@ export class SimpleComponent implements OnInit {
   private readonly logger: ZLUX.ComponentLogger = BaseLogger;
   viewportId: MVDHosting.ViewportId;
   private windowManager: SimpleWindowManagerService;
-  public showLogin:boolean = window.ZOWE_SWM_SHOW_LOGIN == 1 ? true : false;
+  public showLogin:boolean = window.ZOWE_SWM_SHOW_LOGIN == true ? true : false;
   public error:string='';
 
   constructor(

--- a/virtual-desktop/src/desktop.ts
+++ b/virtual-desktop/src/desktop.ts
@@ -15,14 +15,14 @@
  * To set up the desktop, this file must provide a public path for CSS
  * resources, load any external/global stylesheets and scripts, prepare the DOM
  * for the Angular application, and bootstrap the application. The core MVD
- * implementation exists at window.ZoweZLUX.
+ * implementation exists at ZoweZLUX.
  */
 
 
 /* Establish our public path before loading CSS resources */
 // @ts-ignore
 declare let __webpack_public_path__: string;
-const uriBroker = window.ZoweZLUX.uriBroker;
+const uriBroker = ZoweZLUX.uriBroker;
 __webpack_public_path__ = uriBroker.desktopRootUri();
 
 /* Load external/global resources */

--- a/virtual-desktop/src/desktop.ts
+++ b/virtual-desktop/src/desktop.ts
@@ -35,10 +35,10 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { MvdComponent } from 'app/window-manager/mvd-window-manager/mvd.component';
 
 import { MvdModuleFactory } from './app/mvd-module-factory';
-import { SimpleWindowManagerModule } from './app/window-manager/simple-window-manager/simple-window-manager.module';
+// import { SimpleWindowManagerModule } from './app/window-manager/simple-window-manager/simple-window-manager.module';
 import { environment } from './environments/environment';
 import { WindowManagerModule } from 'app/window-manager/mvd-window-manager/window-manager.module';
-import { SimpleComponent } from 'app/window-manager/simple-window-manager/simple.component';
+// import { SimpleComponent } from 'app/window-manager/simple-window-manager/simple.component';
 
 if (environment.production) {
   enableProdMode();
@@ -46,7 +46,7 @@ if (environment.production) {
 
 let mainModule: Type<any>;
 if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-  mainModule = MvdModuleFactory.generateModule(SimpleWindowManagerModule, SimpleComponent);
+  mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
 } else {
   mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
 }

--- a/virtual-desktop/src/desktop.ts
+++ b/virtual-desktop/src/desktop.ts
@@ -35,26 +35,40 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { MvdComponent } from 'app/window-manager/mvd-window-manager/mvd.component';
 
 import { MvdModuleFactory } from './app/mvd-module-factory';
-// import { SimpleWindowManagerModule } from './app/window-manager/simple-window-manager/simple-window-manager.module';
+import { SimpleWindowManagerModule } from './app/window-manager/simple-window-manager/simple-window-manager.module';
 import { environment } from './environments/environment';
 import { WindowManagerModule } from 'app/window-manager/mvd-window-manager/window-manager.module';
-// import { SimpleComponent } from 'app/window-manager/simple-window-manager/simple.component';
+import { SimpleComponent } from 'app/window-manager/simple-window-manager/simple.component';
+import { StartURLManager } from '../src/app/start-url-manager/start-url-manager.service';
 
 if (environment.production) {
   enableProdMode();
 }
 
 let mainModule: Type<any>;
-mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
-// if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-//   mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
-// } else {
-//   mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
-// }
+
+/* Check which window manager to use from URL */
+const app2appArray = StartURLManager.prototype.getApp2AppArgsArray();
+for (let index = 0; index < app2appArray.length; index++) {
+  if (app2appArray[0] && app2appArray.length > 1) {
+    const key = app2appArray[index][0];
+    const value = app2appArray[index][1];
+
+    if (key == "windowManager") {
+      if (value == "mvd" || value == "MVD") {
+        mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
+      } else {
+        mainModule = MvdModuleFactory.generateModule(SimpleWindowManagerModule, SimpleComponent);
+      }
+      break;
+    }
+  }
+}
 
 export function performBootstrap(): void {
   MvdModuleFactory.getTranslationProviders()
-    .then(providers => platformBrowserDynamic().bootstrapModule(mainModule, {providers: providers}));
+    .then(providers => platformBrowserDynamic().bootstrapModule(mainModule
+      || MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent), {providers: providers}));
 }
 
 

--- a/virtual-desktop/src/desktop.ts
+++ b/virtual-desktop/src/desktop.ts
@@ -45,11 +45,12 @@ if (environment.production) {
 }
 
 let mainModule: Type<any>;
-if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-  mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
-} else {
-  mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
-}
+mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
+// if ((window as any)['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+//   mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
+// } else {
+//   mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
+// }
 
 export function performBootstrap(): void {
   MvdModuleFactory.getTranslationProviders()

--- a/virtual-desktop/src/desktop.ts
+++ b/virtual-desktop/src/desktop.ts
@@ -22,7 +22,7 @@
 /* Establish our public path before loading CSS resources */
 // @ts-ignore
 declare let __webpack_public_path__: string;
-const uriBroker = (window as any).ZoweZLUX.uriBroker;
+const uriBroker = window.ZoweZLUX.uriBroker;
 __webpack_public_path__ = uriBroker.desktopRootUri();
 
 /* Load external/global resources */
@@ -48,13 +48,13 @@ if (environment.production) {
 let mainModule: Type<any>;
 
 /* Check which window manager to use from URL */
-const app2appArray = StartURLManager.prototype.getApp2AppArgsArray();
+const app2appArray = StartURLManager.getApp2AppArgsArray();
 for (let index = 0; index < app2appArray.length; index++) {
   const key = app2appArray[index][0];
   const value = app2appArray[index][1];
 
   if (key == "windowManager") {
-    if (value == "mvd" || value == "MVD") {
+    if (value.toUpperCase() == "MVD") {
       mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
     } else {
       mainModule = MvdModuleFactory.generateModule(SimpleWindowManagerModule, SimpleComponent);

--- a/virtual-desktop/src/desktop.ts
+++ b/virtual-desktop/src/desktop.ts
@@ -50,18 +50,16 @@ let mainModule: Type<any>;
 /* Check which window manager to use from URL */
 const app2appArray = StartURLManager.prototype.getApp2AppArgsArray();
 for (let index = 0; index < app2appArray.length; index++) {
-  if (app2appArray[0] && app2appArray.length > 1) {
-    const key = app2appArray[index][0];
-    const value = app2appArray[index][1];
+  const key = app2appArray[index][0];
+  const value = app2appArray[index][1];
 
-    if (key == "windowManager") {
-      if (value == "mvd" || value == "MVD") {
-        mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
-      } else {
-        mainModule = MvdModuleFactory.generateModule(SimpleWindowManagerModule, SimpleComponent);
-      }
-      break;
+  if (key == "windowManager") {
+    if (value == "mvd" || value == "MVD") {
+      mainModule = MvdModuleFactory.generateModule(WindowManagerModule, MvdComponent);
+    } else {
+      mainModule = MvdModuleFactory.generateModule(SimpleWindowManagerModule, SimpleComponent);
     }
+    break;
   }
 }
 


### PR DESCRIPTION
- Makes it such that "pluginId" argument (used for Open In New Tab) now uses app2app to open an app using mvd-window-manager
- Full screen now complete
- Backwards compatibility added for single app mode via "windowManager" URL argument. (Set it to anything other than "MVD" i.e. "old")
- Desktop actions now work (aka in single app mode now exist Notifications, right click Context menu etc., window actions for app2app spawned apps)
- Added support for login page or no login page

![image](https://user-images.githubusercontent.com/20528015/99454370-5483ff00-28f4-11eb-84a6-e94fd5067d47.png)

PR 1/2
PR 2: https://github.com/zowe/zlux-platform/pull/67