### PR TITLE
support minimizing, maximizing via app2app request

### DIFF
--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -200,7 +200,6 @@ export class ApplicationManager implements MVDHosting.ApplicationManagerInterfac
                         +`App ID=${plugin.getIdentifier()}, Instance Obj=`,notATurtle); */
       }
 
-
       return applicationInstance.instanceId;
     }
 

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -115,6 +115,15 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
         this.requestWindowFocus(id);
       }
     });
+    ZoweZLUX.dispatcher.registerEventListener('org.zowe.zlux.windowmanager.maximize',
+                                              (event:any)=>{this.maximize(event.detail.data.id);},
+                                              'org.zowe.zlux.ng2desktop');
+    ZoweZLUX.dispatcher.registerEventListener('org.zowe.zlux.windowmanager.minimize',
+                                              (event:any)=>{this.minimize(event.detail.data.id);},
+                                              'org.zowe.zlux.ng2desktop');
+    ZoweZLUX.dispatcher.registerEventListener('org.zowe.zlux.windowmanager.focus',
+                                              (event:any)=>{this.requestWindowFocus(event.detail.data.id);},
+                                              'org.zowe.zlux.ng2desktop');
     this.screenshotRequestEmitter = new Subject();
     this.windowMonitor.windowResized.subscribe(() => {
       Array.from(this.windowMap.values())


### PR DESCRIPTION
This PR allows for the desktop to listen to the app2app v2 events named org.zowe.zlux.windowmanager. maximize, minimize, and focus. The event.detail attribute must have event.detail.data.id equal to the window ID that is being requested to be changed, and this will tell the window manager to do that action.
This sort of feature already exists in app2app v1, so this is just enabling the same via app2app v2.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>