### PR TITLE
App2App action load fix

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/desktop/desktop.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/desktop/desktop.component.ts
@@ -210,7 +210,9 @@ class AppDispatcherLoader implements MVDHosting.LoginActionInterface {
           const id = plugin.getIdentifier();
           if (appContents[id] && appContents[id].actions) { // If config has pre-existing actions for this plugin id,
             appContents[id].actions.forEach((actionObject: any)=> {
-              ZoweZLUX.dispatcher.addRecognizerObject(actionObject); // register each object with the Dispatcher.
+              if (this.isValidAction(actionObject)) {
+                ZoweZLUX.dispatcher.registerAbstractAction(ZoweZLUX.dispatcher.makeActionFromObject(actionObject));
+              }
             });
             this.log.info(`ZWED5056I`, appContents[id].actions.length, id); //this.log.info(`Loaded ${appContents[id].actions.length} actions for App(${id})`);
           }


### PR DESCRIPTION
It appears that in https://github.com/zowe/zlux-app-manager/pull/246/files#diff-dfe7864d4780d8122b39e71d0a574af186d74ff8166a5580c02e74db4d0e4280R213 a bug was introduced where actions were loaded as recognizers rather than actions, causing an error. This updates the behavior.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>