### PR TITLE
add /iframe path for remote iframe plugins

### DIFF
--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/iframe/iframe-plugin-factory.ts
@@ -60,9 +60,8 @@ export class IFramePluginFactory extends PluginFactory {
     let startingPageUri;
 
     //remote iframe with destination property
-    if(basePlugin.getWebContent().destination>'') {
-      startingPage = '';
-      startingPageUri = ZoweZLUX.uriBroker.pluginIframeUri(basePlugin, startingPage);
+    if(basePlugin.getWebContent().destination > '') {
+      startingPageUri = ZoweZLUX.uriBroker.pluginIframeUri(basePlugin, '');
     }
     //iframe with startingPage property
     else {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
@@ -73,7 +73,12 @@ function openStandalone(item: LaunchbarItem): void {
   //future TODO: initialize cross-window app2app communication??
   if (pluginType === 'iframe' && !(item.plugin.standaloneUseFramework)) {
     // Still allows IFrames to comprehend URL parameters if address is copy/pasted later. Should not break any app2app possibilities
-    window.open(`${location.origin}${ZoweZLUX.uriBroker.pluginResourceUri(item.plugin.getBasePlugin(), item.plugin.getBasePlugin().getWebContent().startingPage)}`);
+    let pluginWebContent = item.plugin.getBasePlugin().getWebContent();
+    if(pluginWebContent.destination > '') {
+      window.open(`${location.origin}${ZoweZLUX.uriBroker.pluginIframeUri(item.plugin.getBasePlugin(), '')}`);
+    } else {
+      window.open(`${location.origin}${ZoweZLUX.uriBroker.pluginResourceUri(item.plugin.getBasePlugin(), pluginWebContent.startingPage)}`);
+    }
   } else {
     window.open(`${location.href}?pluginId=${item.plugin.basePlugin.getIdentifier()}&showLogin=true`);
   }


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

Resolving gap for:
It will resolve to /iframe path, instead of /web
Standalone/Open in new browser tab option
![image](https://user-images.githubusercontent.com/4791635/104509458-b345bc00-55b7-11eb-88ae-b1c4d9ed6183.png)
