### PR TITLE
Improve way to detect cookie name 

### DIFF
--- a/bootstrap/lib/notificationProxy.js
+++ b/bootstrap/lib/notificationProxy.js
@@ -27,6 +27,17 @@ exports.adminNotificationWebsocketRouter = function(context) {
         context.wsRouterPatcher(router);
       }
 
+      const getCookieNameFromRequest = function (req) {
+        const cookieNames = Object.keys(req.cookies);
+        const cookieName = cookieNames.find(name => name.startsWith('connect.sid.'));
+        if (!cookieName) {
+          context.logger.debug('Cookie not found');
+        } else {
+          context.logger.debug(`Cookie name: ${cookieName}`);
+        }
+        return cookieName;
+      }
+
       router.use(function abc(req,res,next) {
         context.logger.info('ZWED0001I'+req.method);
         next();
@@ -75,7 +86,11 @@ exports.adminNotificationWebsocketRouter = function(context) {
         }
       });
       router.ws('/',function(ws,req) {
-        let id = req.cookies["connect.sid." + req.headers['host'].split(":")[1]]
+        const cookieName = getCookieNameFromRequest(req);
+        if (!cookieName) {
+          return;
+        }
+        let id = req.cookies[cookieName];
         let symbols = Object.getOwnPropertySymbols(req.client)
         let asyncId = req.client[symbols[1]]
 
@@ -90,7 +105,11 @@ exports.adminNotificationWebsocketRouter = function(context) {
             instance_ids[index].push(asyncId)
         }
         ws.on('close', ()=> {
-            let id_index = client_ids.indexOf(req.cookies["connect.sid." + req.headers['host'].split(":")[1]])
+            const cookieName = getCookieNameFromRequest(req);
+            if (!cookieName) {
+              return;
+            }
+            let id_index = client_ids.indexOf(req.cookies[cookieName]);
             let symbols_close = Object.getOwnPropertySymbols(req.client)
             let asyncId_close = req.client[symbols_close[1]]
             let asyncId_index = instance_ids[id_index].indexOf(asyncId_close)


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

This PR is a consequence of that we changed how server cookie is named in https://github.com/zowe/zlux-server-framework/pull/307. Now cookie name is
* `connect.sid.<port_number>` when running in non-HA mode
* `connect.sid.<zowe_instance_id>` when running in HA mode

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
