### PR TITLE
Add use of nonce by default

### DIFF
--- a/bootstrap/pluginDefinition.json
+++ b/bootstrap/pluginDefinition.json
@@ -3,7 +3,13 @@
   "apiVersion": "1.0.0",
   "pluginVersion": "0.0.0-zlux.version.replacement",
   "pluginType": "bootstrap",
-  "webContent": {},
+  "webContent": {
+    "headers": {
+      "Content-Security-Policy": {
+        "preset": "script-nonce"
+      }
+    }
+  },
   "configurationData": {
     "resources": {
       "plugins": {


### PR DESCRIPTION
Makes use of https://github.com/zowe/zlux-server-framework/pull/316 to have the desktop only load upon a nonce match.