### PR TITLE
Remove rxjs-compat

### DIFF
--- a/virtual-desktop/src/app/application-manager/application-manager.service.ts
+++ b/virtual-desktop/src/app/application-manager/application-manager.service.ts
@@ -9,7 +9,7 @@
 */
 
 import { Injectable, Injector, NgModuleFactory, Compiler, ComponentRef, Type, SimpleChanges, SimpleChange, OnChanges } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 
 import { PluginLoader } from 'app/plugin-manager/shared/plugin-loader';

--- a/virtual-desktop/src/app/authentication-manager/idleWarn.service.ts
+++ b/virtual-desktop/src/app/authentication-manager/idleWarn.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { ZluxPopupManagerService, ZluxErrorSeverity } from '@zlux/widgets';
 import { TranslationService } from 'angular-l10n';
 import { BaseLogger } from 'virtual-desktop-logger';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 import { StorageService } from './storage.service';
 
 @Injectable()

--- a/virtual-desktop/src/app/i18n/locale-initializer.provider.ts
+++ b/virtual-desktop/src/app/i18n/locale-initializer.provider.ts
@@ -11,7 +11,8 @@
 import { registerLocaleData } from '@angular/common';
 import { Globalization } from './globalization';
 import { LanguageLocaleService } from './language-locale.service';
-import { Observable } from 'rxjs/Rx';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 const logger: ZLUX.ComponentLogger = ZoweZLUX.logger.makeComponentLogger('org.zowe.zlux.virtual-desktop.i18n');
 
@@ -37,10 +38,11 @@ export const localeInitializer = (localeService: LanguageLocaleService, localeId
     const baseLanguage: string = localeService.getBaseLanguage();
     const localeFileURL = `${baseURI}locales/${localeId}`;
     const fallbackLocaleFileURL = baseLanguage !== localeId ? `${baseURI}locales/${baseLanguage}` : null;
-    return loadLocale(localeId, localeFileURL)
-      .catch(err => (fallbackLocaleFileURL != null) ? loadLocale(baseLanguage, fallbackLocaleFileURL) : Observable.of({}))
-      .toPromise()
-      .catch(err => {})
+    return loadLocale(localeId, localeFileURL).pipe(
+      catchError(err => (fallbackLocaleFileURL != null) ? loadLocale(baseLanguage, fallbackLocaleFileURL) : of({}))
+    )
+    .toPromise()
+    .catch(_err => {})
   };
 }
 

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
@@ -16,7 +16,7 @@ import { PluginFactory } from '../plugin-factory';
 import { CompiledPlugin } from '../../shared/compiled-plugin';
 import { Compiler, CompilerOptions, ApplicationRef, Injector } from '@angular/core';
 import { DomPortalOutlet, ComponentPortal } from '@angular/cdk/portal';
-import { Observable } from 'rxjs/Rx';
+import { from, Observable } from 'rxjs';
 
 import { ComponentFactory } from 'zlux-base/registry/registry';
 import { TranslationLoaderService } from '../../../i18n/translation-loader.service';
@@ -77,7 +77,7 @@ class SimpleAngularComponentFactory extends ComponentFactory {
         });
     });
 
-    return Observable.fromPromise(promise);
+    return from(promise);
   }
 }
 

--- a/virtual-desktop/src/app/shared/window-monitor.service.ts
+++ b/virtual-desktop/src/app/shared/window-monitor.service.ts
@@ -12,7 +12,7 @@
 
 import { Injectable } from '@angular/core';
 
-import { Subject, Observable } from 'rxjs/Rx';
+import { Subject, Observable, fromEvent } from 'rxjs';
 
 @Injectable()
 export class WindowMonitor {
@@ -20,7 +20,7 @@ export class WindowMonitor {
 
   constructor() {
     this.windowResized = new Subject();
-    const observable = Observable.fromEvent(window, 'resize') as Observable<UIEvent>;
+    const observable = fromEvent(window, 'resize') as Observable<UIEvent>;
     observable.subscribe(this.windowResized);
   }
 }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
@@ -11,7 +11,7 @@
 */
 
 import { Component, ElementRef, HostListener, Input, Output, EventEmitter, Injector, ViewChild } from '@angular/core';
-import { Subject } from 'rxjs/Subject';
+import { Subject } from 'rxjs';
 import { PluginsDataService } from '../../services/plugins-data.service';
 import { LaunchbarItem } from '../shared/launchbar-item';
 import { ContextMenuItem } from 'pluginlib/inject-resources';

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-widget/launchbar-widget.component.ts
@@ -21,7 +21,7 @@ import {
   ViewChild,
   Input
   } from '@angular/core';
-import { Observable } from 'rxjs/Rx';
+import { interval } from 'rxjs';
 import { DesktopComponent, DesktopTheme } from "../../desktop/desktop.component";
 import { LanguageLocaleService } from '../../../../i18n/language-locale.service';
 import { BaseLogger } from '../../../../shared/logger';
@@ -150,7 +150,7 @@ export class LaunchbarWidgetComponent implements MVDHosting.ZoweNotificationWatc
   ngOnInit(): void {
     this.date = new Date();
 
-    Observable.interval(1000).subscribe(() => this.date = new Date());
+    interval(1000).subscribe(() => this.date = new Date());
   }
 
   getUsername(): string | null {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/services/plugins-data.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/services/plugins-data.service.ts
@@ -11,7 +11,6 @@
 import { Injectable, Injector } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import 'rxjs/add/operator/catch';
 import { LaunchbarItem } from '../launchbar/shared/launchbar-item';
 import { PluginLaunchbarItem } from '../launchbar/shared/launchbar-items/plugin-launchbar-item';
 import { DesktopPluginDefinitionImpl } from '../../../plugin-manager/shared/desktop-plugin-definition';

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -11,7 +11,7 @@
 */
 
 import { Injectable, ViewContainerRef, ComponentRef, ComponentFactoryResolver, Injector } from '@angular/core';
-import { Subject } from 'rxjs/Subject';
+import { Subject } from 'rxjs';
 
 import { DesktopPluginDefinitionImpl } from 'app/plugin-manager/shared/desktop-plugin-definition';
 import { ViewportComponent } from 'app/application-manager/viewport-manager/viewport/viewport.component';

--- a/virtual-desktop/src/externals.ts
+++ b/virtual-desktop/src/externals.ts
@@ -36,7 +36,8 @@ const libs: { [index: string]: {library: any} } = {
   '@angular/router': require('@angular/router'),
   '@angular/animations': require('@angular/animations'),
   'angular-l10n': require('angular-l10n'),
-  'rxjs/Rx': require('rxjs/Rx')
+  'rxjs': require('rxjs'),
+  'rxjs/operators': require('rxjs/operators')
 };
 
 /* Expose modules to requirejs */

--- a/virtual-desktop/src/include.ts
+++ b/virtual-desktop/src/include.ts
@@ -22,7 +22,6 @@
  * least one global style in order to create the desktop itself.
  */
 
-import 'rxjs/Rx';
 import 'style-loader!./styles.css';
 
 

--- a/virtual-desktop/webpack.config.js
+++ b/virtual-desktop/webpack.config.js
@@ -120,7 +120,7 @@ module.exports = {
   mode: 'production',
   "externals": [
     function(context, request, callback) {
-      if (/(@angular)|(angular\-l10n)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs\/Rx$)/.test(request)){
+      if (/(@angular)|(angular\-l10n)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs(\/|$))/.test(request)){
         return callback(null, {
           commonjs: request,
           commonjs2: request,


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
This PR removes `rxjs-compat` library from virtual desktop and updates old-style import statements and operators.

This PR depends upon the following PRs:
* https://github.com/zowe/zlux-platform/pull/80
## Type of change
Please delete options that are not relevant.
- [x] Refactor the code 
- [x] Chore, repository cleanup, updates the dependencies.

