### PR TITLE
rxjs and rxjs/operators are in externals

### DIFF
--- a/virtual-desktop/plugin-config/webpack.base.js
+++ b/virtual-desktop/plugin-config/webpack.base.js
@@ -84,7 +84,7 @@ var config = {
   },
   'externals': [
     function(context, request, callback) {
-      if (/(@angular)|(angular\-l10n)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs\/Rx$)/.test(request)){
+      if (/(@angular)|(angular\-l10n)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs(\/operators)?$)/.test(request)){
         return callback(null, {
           commonjs: request,
           commonjs2: request,

--- a/virtual-desktop/webpack.config.js
+++ b/virtual-desktop/webpack.config.js
@@ -120,7 +120,7 @@ module.exports = {
   mode: 'production',
   "externals": [
     function(context, request, callback) {
-      if (/(@angular)|(angular\-l10n)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs(\/|$))/.test(request)){
+      if (/(@angular)|(angular\-l10n)|(^bootstrap$)|(^popper.js$)|(^jquery$)|(^rxjs(\/operators)?$)/.test(request)){
         return callback(null, {
           commonjs: request,
           commonjs2: request,


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Update `webpack.base.config.js` because `rxjs` and `rxjs/operators` are now in externals.


## Type of change
- [x] New feature (non-breaking change which adds functionality)
