### PR TITLE
Fix Iframe adapter + replace snapshot code with simpler UI to nearly completely eliminate Desktop multi apps slowdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Manager will be documented in this file.
 
+## `2.8.0`
+- Bugfix: Fixed the iframe-adapter not properly recognizing standalone mode
+- Enhancement: Added new isSingleAppModeSimple() to iframe-adapter to differentiate between standalone mode and simple standalone mode
+
 ## `2.0.0`
 
 - Enhancement: New desktop library versions: Angular 6->12, Corejs 2->3, Typescript 2->4 etc. For more information, visit https://www.zowe.org/vnext

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the Zlux App Manager will be documented in this file.
 
 ## `2.8.0`
 - Bugfix: Fixed the iframe-adapter not properly recognizing standalone mode
+- Bugfix: Fixed Iframes from unintentionally loading their sources multiple times during refocus & multi-app situations
 - Enhancement: Added new isSingleAppModeSimple() to iframe-adapter to differentiate between standalone mode and simple standalone mode
+- Enhancement: Replace existing snapshot preview with lighter UI to magnitudes increase multi-app Desktop performance
 
 ## `2.0.0`
 

--- a/bootstrap/src/main.ts
+++ b/bootstrap/src/main.ts
@@ -36,7 +36,6 @@ function processApp2AppArgs(url?: string): void {
     switch (key) {
       case "pluginId":
         window['GIZA_PLUGIN_TO_BE_LOADED'] = value;
-        window['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
         window['GIZA_ENVIRONMENT'] = 'MVD';
         pluginId = value;
         break;
@@ -49,16 +48,17 @@ function processApp2AppArgs(url?: string): void {
         break;
       case "windowManager":
         windowManager = value;
+        if (!windowManager || windowManager.toUpperCase() !== 'MVD') {
+          window['GIZA_SIMPLE_CONTAINER_REQUESTED'] = true;
+        }
         break;
     }
   });
 
   if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
-    if (windowManager && windowManager.toUpperCase() === 'MVD') {
-      console.log(`ZWED5043I - MVD standalone container requested with pluginId ${pluginId}`);
-    } else {
-      console.log(`ZWED5003I - Simple container requested with pluginId ${pluginId}`);
-    }
+    console.log(`ZWED5003I - Simple container requested with pluginId ${pluginId}`);
+  } else {
+    console.log(`ZWED5043I - MVD standalone container requested with pluginId ${pluginId}`);
   }
 }
 

--- a/bootstrap/web/iframe-adapter.js
+++ b/bootstrap/web/iframe-adapter.js
@@ -183,27 +183,54 @@ var ZoweZLUX = {
         pluginDef: undefined,
         launchMetadata: undefined,
 
-        //True - Standalone, False - We are in regular desktop mode
+        //True - Single app mode, False - We are in regular desktop mode
         isSingleAppMode() {
             return new Promise(function(resolve, reject)  {
-                if (window.GIZA_SIMPLE_CONTAINER_REQUESTED) { //Ancient edgecase
+                if (window.top.GIZA_PLUGIN_TO_BE_LOADED) { //Ancient edgecase
+                    resolve(true); //Standalone mode
+                } else { // The below hacky edgecase is to account for timing issues
+                    // let intervalId = setInterval(checkForStandaloneMode, 100);
+                    // function checkForStandaloneMode() {
+                    //     if (ZoweZLUX.iframe.pluginDef) { //If we have the plugin definition
+                    //         clearInterval(intervalId);
+                    //         resolve(false);
+                    //     }
+                    // }
+                    // setTimeout(() => { 
+                    //     clearInterval(intervalId);
+                    //     if (ZoweZLUX.iframe.pluginDef === undefined || null) {
+                    //         resolve(true);
+                    //     } else {
+                    //         resolve(false);
+                    //     }
+                    // }, 1000);
+                    resolve(false);
+                }
+            });
+        },
+
+        //True - Standalone + using simple window manager, False - We are in regular desktop or using the MVD window manager for single app mode
+        isSingleAppModeSimple() {
+            return new Promise(function(resolve, reject)  {
+                if (window.top.GIZA_SIMPLE_CONTAINER_REQUESTED) { //Ancient edgecase
                     resolve(true); //Standalone mode
                 } else {
-                let intervalId = setInterval(checkForStandaloneMode, 100);
-                function checkForStandaloneMode() {
-                    if (ZoweZLUX.iframe.pluginDef) { //If we have the plugin definition
-                        clearInterval(intervalId);
-                        resolve(false);
-                    }
-                }
-                setTimeout(() => { 
-                    clearInterval(intervalId);
-                    if (ZoweZLUX.iframe.pluginDef === undefined || null) {
-                        resolve(true);
-                    } else {
-                        resolve(false);
-                    }
-                }, 1000);
+                    // let intervalId = setInterval(checkForStandaloneMode, 100);
+                    // function checkForStandaloneMode() {
+                    //     if (ZoweZLUX.iframe.pluginDef) { //If we have the plugin definition
+                    //         clearInterval(intervalId);
+                    //         resolve(false);
+                    //     }
+                    // }
+                    // setTimeout(() => { 
+                    //     clearInterval(intervalId);
+                    //     if (ZoweZLUX.iframe.pluginDef === undefined || null) {
+                    //         resolve(true);
+                    //     } else {
+                    //         resolve(false);
+                    //     }
+                    // }, 1000);
+                    resolve(false);
                 }
             });
         }

--- a/bootstrap/web/iframe-adapter.js
+++ b/bootstrap/web/iframe-adapter.js
@@ -188,22 +188,7 @@ var ZoweZLUX = {
             return new Promise(function(resolve, reject)  {
                 if (window.top.GIZA_PLUGIN_TO_BE_LOADED) { //Ancient edgecase
                     resolve(true); //Standalone mode
-                } else { // The below hacky edgecase is to account for timing issues
-                    // let intervalId = setInterval(checkForStandaloneMode, 100);
-                    // function checkForStandaloneMode() {
-                    //     if (ZoweZLUX.iframe.pluginDef) { //If we have the plugin definition
-                    //         clearInterval(intervalId);
-                    //         resolve(false);
-                    //     }
-                    // }
-                    // setTimeout(() => { 
-                    //     clearInterval(intervalId);
-                    //     if (ZoweZLUX.iframe.pluginDef === undefined || null) {
-                    //         resolve(true);
-                    //     } else {
-                    //         resolve(false);
-                    //     }
-                    // }, 1000);
+                } else { 
                     resolve(false);
                 }
             });
@@ -215,21 +200,6 @@ var ZoweZLUX = {
                 if (window.top.GIZA_SIMPLE_CONTAINER_REQUESTED) { //Ancient edgecase
                     resolve(true); //Standalone mode
                 } else {
-                    // let intervalId = setInterval(checkForStandaloneMode, 100);
-                    // function checkForStandaloneMode() {
-                    //     if (ZoweZLUX.iframe.pluginDef) { //If we have the plugin definition
-                    //         clearInterval(intervalId);
-                    //         resolve(false);
-                    //     }
-                    // }
-                    // setTimeout(() => { 
-                    //     clearInterval(intervalId);
-                    //     if (ZoweZLUX.iframe.pluginDef === undefined || null) {
-                    //         resolve(true);
-                    //     } else {
-                    //         resolve(false);
-                    //     }
-                    // }, 1000);
                     resolve(false);
                 }
             });

--- a/bootstrap/web/iframe-adapter.js
+++ b/bootstrap/web/iframe-adapter.js
@@ -72,7 +72,8 @@ let messageHandler = function(message) {
                 window.dispatchEvent(restored)
                 return;
             case 'windowEvents.resized':
-                //console.log('resized')
+                let resized = new CustomEvent('ZoweZLUX.windowEvents', {detail: {event:'resized'}});
+                window.dispatchEvent(resized);
                 return;
             case 'windowEvents.titleChanged':
                 let titleChanged = new CustomEvent('ZoweZLUX.windowEvents', {detail: {event:'titleChange'}});

--- a/virtual-desktop/src/app/authentication-manager/login/login.component.ts
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.ts
@@ -194,7 +194,7 @@ export class LoginComponent implements OnInit {
           }
         }
         this.isLoading = false;
-        if (!this.showLogin && window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (!this.showLogin && window['GIZA_PLUGIN_TO_BE_LOADED']) {
           this.authenticationService.spawnApplicationsWithNoUsername();
           this.enableExpirationPrompt = false;
           this.needLogin = false;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.css
@@ -50,6 +50,11 @@
     margin-top: -10px;
 }
 
+.instance-preview-caption {
+    font-size: large; 
+    padding-top: 1rem;
+}
+
 .instance-snapshot:hover .instance-preview {
     opacity: 0.5;
 }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.css
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.css
@@ -12,9 +12,8 @@
 
 .instance-item {
     width: 200px;
-    height: 120px;
-    margin-left: 3px;
-    margin-right: 3px;
+    height: 140px;
+    margin: 3px;
 }
 
 .instance-viewer {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.html
@@ -11,12 +11,15 @@
      [style.background]="color.launchbarMenuColor"
      [style.color]="color.launchbarMenuText">
   <div class="all-instances-box">
-    <div class="instance-item" (mousedown)="clicked(windowId, launchbarItem)" *ngFor="let windowId of windowManager.getWindowIDs(launchbarItem.plugin); let i = index">
-      <div>
-      <p class="caption truncate">{{getTitleForWindow(windowId)}}</p>
+    <div class="instance-item" [style.background]="color.windowColorInactive" (mousedown)="clicked(windowId, launchbarItem)" *ngFor="let windowId of windowManager.getWindowIDs(launchbarItem.plugin); let i = index">
+      <div *ngIf="isWindowFocused(windowId)" [style.background]="color.launchbarColor">
+        <p class="caption truncate" style="font-size: large; padding-top: 1rem;">{{i}} {{getTitleForWindow(windowId)}}</p>
+      </div>
+      <div *ngIf="!isWindowFocused(windowId)">
+        <p class="caption truncate" style="font-size: large; padding-top: 1rem;">{{i}} {{getTitleForWindow(windowId)}}</p>
       </div>
       <div class="instance-snapshot" (click)="clicked(windowId)" [style.background-color]="black">
-        <img class="instance-preview" src={{getPreview(i,launchbarItem)}} alt="{{i}} {{getTitleForWindow(windowId)}}"/>
+        <!-- <img class="instance-preview" src={{getPreview(i,launchbarItem)}} alt="{{i}} {{getTitleForWindow(windowId)}}"/> -->
       </div>
     </div>
   </div>

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.html
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.html
@@ -13,10 +13,10 @@
   <div class="all-instances-box">
     <div class="instance-item" [style.background]="color.windowColorInactive" (mousedown)="clicked(windowId, launchbarItem)" *ngFor="let windowId of windowManager.getWindowIDs(launchbarItem.plugin); let i = index">
       <div *ngIf="isWindowFocused(windowId)" [style.background]="color.launchbarColor">
-        <p class="caption truncate" style="font-size: large; padding-top: 1rem;">{{i}} {{getTitleForWindow(windowId)}}</p>
+        <p class="caption truncate instance-preview-caption">{{i}} {{getTitleForWindow(windowId)}}</p>
       </div>
       <div *ngIf="!isWindowFocused(windowId)">
-        <p class="caption truncate" style="font-size: large; padding-top: 1rem;">{{i}} {{getTitleForWindow(windowId)}}</p>
+        <p class="caption truncate instance-preview-caption">{{i}} {{getTitleForWindow(windowId)}}</p>
       </div>
       <div class="instance-snapshot" (click)="clicked(windowId)" [style.background-color]="black">
         <!-- <img class="instance-preview" src={{getPreview(i,launchbarItem)}} alt="{{i}} {{getTitleForWindow(windowId)}}"/> -->

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-instance-view/launchbar-instance-view.component.ts
@@ -67,6 +67,10 @@ export class LaunchbarInstanceViewComponent {
     return title;
   }
 
+  isWindowFocused(windowId: MVDWindowManagement.WindowId): boolean {
+    return this.windowManager.windowHasFocus(windowId);
+  }
+
   clicked(windowId: MVDWindowManagement.WindowId, item: LaunchbarItem): void {
     this.windowManager.requestWindowFocus(windowId);
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar-menu/launchbar-menu.component.ts
@@ -146,7 +146,7 @@ export class LaunchbarMenuComponent implements MVDHosting.LoginActionInterface{
     this.appKeyboard.keyUpEvent
       .subscribe((event:KeyboardEvent) => {
         // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
-        if (event.which === KeyCode.KEY_M && !window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (event.which === KeyCode.KEY_M && !window['GIZA_PLUGIN_TO_BE_LOADED']) {
           this.activeToggle();
         }
     });

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/launchbar/launchbar.component.ts
@@ -77,7 +77,7 @@ export class LaunchbarComponent implements MVDHosting.LogoutActionInterface {
     }
 
     // TODO: Disable bottom app bar once mvd-window-manager single app mode is functional. Variable subject to change.
-    if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+    if (window['GIZA_PLUGIN_TO_BE_LOADED']) {
       this.displayAppBar = "none";
     } else {
       this.displayAppBar = "inherit";

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/launchbar-items/plugin-launchbar-item.ts
@@ -38,7 +38,8 @@ export class PluginLaunchbarItem extends LaunchbarItem{// implements ZLUX.Plugin
       }
       let index = this.instanceIds.indexOf(window.windowId);
       if (index != -1) {
-        this.generateSnapshot(index);
+        // TODO: Generate snapshot code needs optimization due to incredible desktop performance slowdown
+        // this.generateSnapshot(index);
       }
     });
   }
@@ -92,18 +93,20 @@ export class PluginLaunchbarItem extends LaunchbarItem{// implements ZLUX.Plugin
   }
 
   instanceAdded(instanceId: MVDHosting.InstanceId, isEmbedded: boolean|undefined) {
-    var self = this;
+    //var self = this;
     if (!isEmbedded) {
       this.instanceIds.push(instanceId);
-      let index = this.instanceIds.length-1;
+      //let index = this.instanceIds.length-1;
       if (this.instanceIds.length != 1) {
         //skip first for performance
         setTimeout(function() {
-          self.generateSnapshot(index);
+          // TODO: Generate snapshot code needs optimization due to incredible desktop performance slowdown
+          //self.generateSnapshot(index);
         }, 3000);
       } if (this.instanceIds.length == 2) {
         //go back and init first. slightly worse for performance
-        self.generateSnapshot(0);
+        // TODO: Generate snapshot code needs optimization due to incredible desktop performance slowdown
+        //self.generateSnapshot(0);
       }
     }
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -57,7 +57,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private focusedWindow: DesktopWindow | null;
   private topZIndex: number;
   //private _lastScreenshotPluginId: string = '';  
-  private _lastScreenshotWindowId: number = -1;
+  //private _lastScreenshotWindowId: number = -1;
   public showPersonalizationPanel: boolean = false;
   private autoSaveInterval : number = 300000;
   public autoSaveFiles : {[key:string]:number} = {};
@@ -758,9 +758,9 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
       return false;
     }
     //let requestScreenshot = false;
-    if (!this.windowHasFocus(destination) && this._lastScreenshotWindowId != destination){
+    //if (!this.windowHasFocus(destination) && this._lastScreenshotWindowId != destination){
       //requestScreenshot = true;
-    }
+    //}
 
     //can't focus an unseen window!
     if (desktopWindow.windowState.stateType === DesktopWindowStateType.Minimized) {

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -144,7 +144,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
       .subscribe((event:KeyboardEvent) => {
         if (event.which === KeyCode.DOWN_ARROW) {
           // TODO: Disable minimize hotkey once mvd-window-manager single app mode is functional. Variable subject to change.
-          if(this.focusedWindow && !window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+          if(this.focusedWindow && !window['GIZA_PLUGIN_TO_BE_LOADED']) {
             this.minimizeToggle(this.focusedWindow.windowId);
           }
         }
@@ -273,7 +273,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
   private refreshMaximizedWindowSize(desktopWindow: DesktopWindow): void {
     //This is the window viewport size, so you must subtract the header and launchbar from the height, if not in standalone mode.
     let height;
-    if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+    if (window['GIZA_PLUGIN_TO_BE_LOADED']) {
       height = window.innerHeight;
     } else {
       height = window.innerHeight - WindowManagerService.MAXIMIZE_WINDOW_HEIGHT_OFFSET;

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/shared/window-manager.service.ts
@@ -56,7 +56,7 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
 
   private focusedWindow: DesktopWindow | null;
   private topZIndex: number;
-  private _lastScreenshotPluginId: string = '';  
+  //private _lastScreenshotPluginId: string = '';  
   private _lastScreenshotWindowId: number = -1;
   public showPersonalizationPanel: boolean = false;
   private autoSaveInterval : number = 300000;
@@ -757,9 +757,9 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
       this.logger.warn("ZWED5187W", destination); //this.logger.warn('Attempted to request focus for null window, ID=${destination}');
       return false;
     }
-    let requestScreenshot = false;
+    //let requestScreenshot = false;
     if (!this.windowHasFocus(destination) && this._lastScreenshotWindowId != destination){
-      requestScreenshot = true;
+      //requestScreenshot = true;
     }
 
     //can't focus an unseen window!
@@ -769,13 +769,14 @@ export class WindowManagerService implements MVDWindowManagement.WindowManagerSe
 
     this.focusedWindow = desktopWindow;
     desktopWindow.windowState.zIndex = this.topZIndex ++;
-    if (requestScreenshot){
-      setTimeout(()=> {
-        this.screenshotRequestEmitter.next({pluginId: this._lastScreenshotPluginId, windowId: this._lastScreenshotWindowId});
-        this._lastScreenshotWindowId = destination;
-        this._lastScreenshotPluginId = desktopWindow.plugin.getIdentifier();
-      },500); //delay a bit for performance perception
-    }
+    // TODO: Generate snapshot code needs optimization due to incredible desktop performance slowdown
+    // if (requestScreenshot){
+    //   setTimeout(()=> {
+    //     this.screenshotRequestEmitter.next({pluginId: this._lastScreenshotPluginId, windowId: this._lastScreenshotWindowId});
+    //     this._lastScreenshotWindowId = destination;
+    //     this._lastScreenshotPluginId = desktopWindow.plugin.getIdentifier();
+    //   },500); //delay a bit for performance perception
+    // }
     this.setDesktopTitle(desktopWindow.windowTitle);
     return true;
   }

--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/window/window.component.ts
@@ -69,7 +69,7 @@ export class WindowComponent {
         this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
-        if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (window['GIZA_PLUGIN_TO_BE_LOADED']) {
           this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
@@ -86,7 +86,7 @@ export class WindowComponent {
         this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
-        if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (window['GIZA_PLUGIN_TO_BE_LOADED']) {
           this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
@@ -103,7 +103,7 @@ export class WindowComponent {
         this.displayMinimize = true;
 
         // TODO: Disable minimize button once mvd-window-manager single app mode is functional. Variable subject to change.
-        if (window['GIZA_SIMPLE_CONTAINER_REQUESTED']) {
+        if (window['GIZA_PLUGIN_TO_BE_LOADED']) {
           this.displayMinimize = false;
           this.maximizeLeft = this.minimizeLeft;
         }
@@ -161,7 +161,7 @@ export class WindowComponent {
     this.maxWidth = '100%';
     this.zIndex = this.desktopWindow.windowState.zIndex;
     // In standalone app mode, our launchbar doesn't exist
-    this.launchbarHeight = (window.GIZA_SIMPLE_CONTAINER_REQUESTED ? 0 : WindowManagerService.LAUNCHBAR_HEIGHT);
+    this.launchbarHeight = (window.GIZA_PLUGIN_TO_BE_LOADED ? 0 : WindowManagerService.LAUNCHBAR_HEIGHT);
 
     /* These 4 conditionals check if a window is out of bounds by checking if a window has been
     dragged too far out of view, in either of the 4 directions, and locks it from going further. */


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR fixes the bug where the isSingleAppMode( ) method no longer works as intended 

(can be seen via opening the Sample Iframe App in standalone mode and seeing that despite in the code, notifications are disabled for isSingleAppMode - which they shouldn't be because we can still use them from the MVD window manager enhancement even in standalone mode - but they are visible in the UI. This is because isSingleAppMode( ) atm always returns TRUE https://github.com/zowe/sample-iframe-app/blob/ca132f90482efba62623bbb61c6498785a7217ab/web/html/index.html#L76)

It also creates isSingleAppModeSimple( ) which means an app is in single app mode + using simple window manager

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

So for testing, the changes are basically:
GIZA_SIMPLE_CONTAINER_REQUESTED --> now is only true when we are in simple mode, not just standalone mode
GIZA_PLUGIN_TO_BE_LOADED --> now used in place of GIZA_SIMPLE_CONTAINER_REQUESTED across zlux-app-manager to tell if we are in standalone mode which the incorrectly named GIZA_SIMPLE_CONTAINER_REQUESTED did before

iframe-adapter.js has been updated to reflect above ^
