### PR TITLE
Added resized event

### DIFF
--- a/bootstrap/web/iframe-adapter.js
+++ b/bootstrap/web/iframe-adapter.js
@@ -72,7 +72,8 @@ let messageHandler = function(message) {
                 window.dispatchEvent(restored)
                 return;
             case 'windowEvents.resized':
-                //console.log('resized')
+                let resized = new CustomEvent('ZoweZLUX.windowEvents', {detail: {event:'resized'}});
+                window.dispatchEvent(resized);
                 return;
             case 'windowEvents.titleChanged':
                 let titleChanged = new CustomEvent('ZoweZLUX.windowEvents', {detail: {event:'titleChange'}});


### PR DESCRIPTION
## Proposed changes
This PR adds missing resized event to windowEvents in iframe addapter.

Before changes the it was impossible to receive resized event using iframe addapter.

## Type of change
 Bug fix (non-breaking change which fixes an issue)

## Testing 
Add event Listener for windowEvents, it should be receiving events for resizing.