### PR TITLE
Revert old timing code to better handle timing situations (fixes Firefox bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux App Manager will be documented in this file.
 
+## `2.10.0`
+- Bugfix: Fixed a timing issue with the iframe-adapter for Firefox
+
 ## `2.8.0`
 - Bugfix: Fixed the iframe-adapter not properly recognizing standalone mode
 - Bugfix: Fixed Iframes from unintentionally loading their sources multiple times during refocus & multi-app situations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Manager will be documented in this file.
 
 ## `2.10.0`
-- Bugfix: Fixed a timing issue with the iframe-adapter for Firefox
+- Bugfix: Fixed a timing issue with the iframe-adapter for Firefox (#532)
 
 ## `2.8.0`
 - Bugfix: Fixed the iframe-adapter not properly recognizing standalone mode

--- a/bootstrap/web/iframe-adapter.js
+++ b/bootstrap/web/iframe-adapter.js
@@ -187,22 +187,52 @@ var ZoweZLUX = {
         //True - Single app mode, False - We are in regular desktop mode
         isSingleAppMode() {
             return new Promise(function(resolve, reject)  {
-                if (window.top.GIZA_PLUGIN_TO_BE_LOADED) { //Ancient edgecase
+                if (window.top.GIZA_PLUGIN_TO_BE_LOADED) {
                     resolve(true); //Standalone mode
-                } else { 
-                    resolve(false);
-                }
+                } else {
+                    //resolve(false) doesn't work great here and fails timing situations in some browsers (for example: Firefox)
+                    let intervalId = setInterval(checkForStandaloneMode, 100);
+                    function checkForStandaloneMode() {
+                        if (ZoweZLUX.iframe.pluginDef) { //If we have the plugin definition
+                            clearInterval(intervalId);
+                            resolve(false);
+                        }
+                    }
+                    setTimeout(() => { 
+                        clearInterval(intervalId);
+                        if (ZoweZLUX.iframe.pluginDef === undefined || null) {
+                            resolve(true);
+                        } else {
+                            resolve(false);
+                        }
+                    }, 1000);
+                    }
             });
         },
 
         //True - Standalone + using simple window manager, False - We are in regular desktop or using the MVD window manager for single app mode
         isSingleAppModeSimple() {
             return new Promise(function(resolve, reject)  {
-                if (window.top.GIZA_SIMPLE_CONTAINER_REQUESTED) { //Ancient edgecase
+                if (window.top.GIZA_SIMPLE_CONTAINER_REQUESTED) {
                     resolve(true); //Standalone mode
                 } else {
-                    resolve(false);
-                }
+                    //resolve(false) doesn't work great here and fails timing situations in some browsers (for example: Firefox)
+                    let intervalId = setInterval(checkForStandaloneMode, 100);
+                    function checkForStandaloneMode() {
+                        if (ZoweZLUX.iframe.pluginDef) { //If we have the plugin definition
+                            clearInterval(intervalId);
+                            resolve(false);
+                        }
+                    }
+                    setTimeout(() => { 
+                        clearInterval(intervalId);
+                        if (ZoweZLUX.iframe.pluginDef === undefined || null) {
+                            resolve(true);
+                        } else {
+                            resolve(false);
+                        }
+                    }, 1000);
+                    }
             });
         }
     },


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

[This PR ](https://github.com/zowe/zlux-app-manager/pull/507) added good features to the Desktop and removed bugs, but unfortunately I also added a regression by removing a timing situation check that I tested to be alright to remove on my browser Chrome. However, on Firefox while the methods work, if you call it too early in your app's init (like startup - which many apps do) it won't behave as intended. Therefore, making partial revert

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

Can be provided on request, needs an Iframe app on Firefox that utilizes Iframe adapter methods

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
