### PR TITLE
Do not add username to local storage

### DIFF
--- a/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
+++ b/virtual-desktop/src/app/authentication-manager/authentication-manager.service.ts
@@ -332,7 +332,6 @@ export class AuthenticationManager {
       let jsonMessage = (result as any);
       if (jsonMessage && jsonMessage.success === true) {
         this.setSessionTimeoutWatcher(jsonMessage.categories);
-        window.localStorage.setItem('username', username);
         this.username = username;
         (ZoweZLUX.logger as any)._setBrowserUsername(username);
         this.performPostLoginActions().subscribe(


### PR DESCRIPTION
This appears to be old code with no consequence, but security scanners recommend against storing unnecessary things in local storage, and username is arguably one of those things that has no reason to be there.
I checked a few things in the browser and couldn't find a reason this was ever there. I think it was just very old code for demo purposes or something. It doesn't seem to break anything in the Desktop that I tried.