### PR TITLE
Feature/automate changelog note

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -44,79 +44,82 @@ jobs:
           github-repo: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  update-changelog:
-    runs-on: ubuntu-latest
-    outputs:
-      was_updated: ${{ steps.check-change.outputs.change_detected }}
-      check_commit: ${{ steps.check-changelog.outputs.check_commit }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
+  jobs:
+    update-changelog:
+      runs-on: ubuntu-latest
+      outputs:
+        was_updated: ${{ steps.check-change.outputs.change_detected }}
+        check_commit: ${{ steps.check-changelog.outputs.check_commit }}
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+          with:
+            ref: ${{ github.head_ref }}
+            fetch-depth: 0
 
-      - name: Check for updated CHANGELOG.md using git
-        id: check-changelog
-        run: |
-          if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
-            echo "CHANGELOG.md has been updated."
-            echo "::set-output name=check_commit::true"
-          else
-            echo "ERROR: CHANGELOG.md has not been updated."
-            echo "::set-output name=check_commit::false"
-          fi
-      - name: Extract changelog info
-        if: steps.check-changelog.outputs.check_commit == 'false'
-        id: extract-changelog
-        run: |
-          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
-          # Check if "changelog:" exists in PR description
-          if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
-            # Extract text after "changelog:"
-            CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
-            # Extract VERSION: from PR description
-            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')
-            echo "Extracted changelog: $CHANGELOG_TEXT"
-            echo "::set-output name=changelog::$CHANGELOG_TEXT"
-            echo "::set-output name=version::$VERSION"
-          else
-            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
-            To re-run the action, just pushed/commit the changes along with PR description, it will automatically triggered by sync."
-            exit 1
-          fi
-      - name: Check PR body against changelog
-        if: steps.check-changelog.outputs.check_commit == 'false'
-        run: |
-          if ! grep -Fq "${{ steps.extract-changelog.outputs.changelog }}" CHANGELOG.md; then
-          # Check if version exists in CHANGELOG.md
-            if grep -q "## ${{ steps.extract-changelog.outputs.version }}" CHANGELOG.md; then
-              # Append PR description to existing version
-              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} (#${{ github.event.pull_request.number }})" CHANGELOG.md
+        - name: Check for updated CHANGELOG.md using git
+          id: check-changelog
+          run: |
+            if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
+              echo "CHANGELOG.md has been updated."
+              echo "::set-output name=check_commit::true"
             else
-              # Append new version and PR description
-              echo "$(awk '/All notable changes to the Zlux App Server package will be documented in this file\./ {
-                print
-                print "\n## " "${{ steps.extract-changelog.outputs.version }}"
-                print "- " "${{ steps.extract-changelog.outputs.changelog }}" " (#${{ github.event.pull_request.number }})"
-                next
-              } 1' CHANGELOG.md)" > CHANGELOG.md
-           fi
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
-            git add CHANGELOG.md
-            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
-            git push
-          fi
-      - name: check for changes
-        id: check-change
-        run: |
-          if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
-            echo "No Changes detected, setting flag to false"
-            echo "::set-output name=change_detected::false"
-          else
-            echo "::set-output name=change_detected::true"
-          fi
+              echo "ERROR: CHANGELOG.md has not been updated."
+              echo "::set-output name=check_commit::false"
+            fi
+        - name: Extract changelog info
+          if: steps.check-changelog.outputs.check_commit == 'false'
+          id: extract-changelog
+          run: |
+            PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+            # Check if "changelog:" exists in PR description
+            if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
+              # Extract text after "changelog:"
+              CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
+              # Extract VERSION: from PR description
+              VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')        
+              echo "Extracted changelog: $CHANGELOG_TEXT"
+              echo "::set-output name=changelog::$CHANGELOG_TEXT"
+              echo "::set-output name=version::$VERSION"
+            else
+              echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
+              To re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
+              exit 1
+            fi
+        - name: Check PR body against changelog
+          if: steps.check-changelog.outputs.check_commit == 'false'
+          run: |
+            ESCAPED_CHANGELOG="${{ steps.extract-changelog.outputs.changelog }}"
+            ESCAPED_CHANGELOG=$(echo "$ESCAPED_CHANGELOG" | sed "s/'/\\\\'/g")
+            VERSION="${{ steps.extract-changelog.outputs.version }}"
+
+            if ! grep -Fq "$ESCAPED_CHANGELOG" CHANGELOG.md; then
+              # Check if version exists in CHANGELOG.md
+              if grep -q "^## \`$VERSION\`" CHANGELOG.md; then
+                # Append PR description to existing version
+                sed -i "/^## \`$VERSION\`/a - $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})" CHANGELOG.md
+              else
+                # Append new version (with backticks) and PR description below the anchor line
+                ANCHOR_LINE=$(awk '/All notable changes to the Zlux App Manager will be documented in this file\./ {print NR}' CHANGELOG.md)
+                sed -i "$ANCHOR_LINE a\\
+                \n## \`$VERSION\`\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
+              fi
+              git config --local user.email "action@github.com"
+              git config --local user.name "GitHub Action"
+              git add CHANGELOG.md
+              git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+              git push
+            fi
+
+        - name: check for changes
+          id: check-change
+          run: |
+            if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
+              echo "No Changes detected, setting flag to false"
+              echo "::set-output name=change_detected::false"
+            else
+              echo "::set-output name=change_detected::true"
+            fi
 
   check_changelog:
       needs: update-changelog
@@ -132,8 +135,9 @@ jobs:
               exit 1
             else
               echo "changelog was updated successfully."
-            fi
-        
+            fi    
+
+
   build:
     runs-on: ubuntu-latest
     needs: check-permission

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -44,99 +44,97 @@ jobs:
           github-repo: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  jobs:
-    update-changelog:
-      runs-on: ubuntu-latest
-      outputs:
-        was_updated: ${{ steps.check-change.outputs.change_detected }}
-        check_commit: ${{ steps.check-changelog.outputs.check_commit }}
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
-          with:
-            ref: ${{ github.head_ref }}
-            fetch-depth: 0
+  update-changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      was_updated: ${{ steps.check-change.outputs.change_detected }}
+      check_commit: ${{ steps.check-changelog.outputs.check_commit }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
-        - name: Check for updated CHANGELOG.md using git
-          id: check-changelog
-          run: |
-            if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
-              echo "CHANGELOG.md has been updated."
-              echo "::set-output name=check_commit::true"
-            else
-              echo "ERROR: CHANGELOG.md has not been updated."
-              echo "::set-output name=check_commit::false"
-            fi
-        - name: Extract changelog info
-          if: steps.check-changelog.outputs.check_commit == 'false'
-          id: extract-changelog
-          run: |
-            PR_DESCRIPTION="${{ github.event.pull_request.body }}"
-            # Check if "changelog:" exists in PR description
-            if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
-              # Extract text after "changelog:"
-              CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
-              # Extract VERSION: from PR description
-              VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')        
-              echo "Extracted changelog: $CHANGELOG_TEXT"
-              echo "::set-output name=changelog::$CHANGELOG_TEXT"
-              echo "::set-output name=version::$VERSION"
-            else
-              echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
-              To re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
-              exit 1
-            fi
-        - name: Check PR body against changelog
-          if: steps.check-changelog.outputs.check_commit == 'false'
-          run: |
-            ESCAPED_CHANGELOG="${{ steps.extract-changelog.outputs.changelog }}"
-            ESCAPED_CHANGELOG=$(echo "$ESCAPED_CHANGELOG" | sed "s/'/\\\\'/g")
-            VERSION="${{ steps.extract-changelog.outputs.version }}"
+      - name: Check for updated CHANGELOG.md using git
+        id: check-changelog
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
+            echo "CHANGELOG.md has been updated."
+            echo "::set-output name=check_commit::true"
+          else
+            echo "ERROR: CHANGELOG.md has not been updated."
+            echo "::set-output name=check_commit::false"
+          fi
+      - name: Extract changelog info
+        if: steps.check-changelog.outputs.check_commit == 'false'
+        id: extract-changelog
+        run: |
+          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+          # Check if "changelog:" exists in PR description
+          if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
+            # Extract text after "changelog:"
+            CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
+            # Extract VERSION: from PR description
+            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')        
+            echo "Extracted changelog: $CHANGELOG_TEXT"
+            echo "::set-output name=changelog::$CHANGELOG_TEXT"
+            echo "::set-output name=version::$VERSION"
+          else
+            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
+            To re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
+            exit 1
+          fi
+      - name: Check PR body against changelog
+        if: steps.check-changelog.outputs.check_commit == 'false'
+        run: |
+          ESCAPED_CHANGELOG="${{ steps.extract-changelog.outputs.changelog }}"
+          ESCAPED_CHANGELOG=$(echo "$ESCAPED_CHANGELOG" | sed "s/'/\\\\'/g")
+          VERSION="${{ steps.extract-changelog.outputs.version }}"
 
-            if ! grep -Fq "$ESCAPED_CHANGELOG" CHANGELOG.md; then
-              # Check if version exists in CHANGELOG.md
-              if grep -q "^## \`$VERSION\`" CHANGELOG.md; then
-                # Append PR description to existing version
-                sed -i "/^## \`$VERSION\`/a - $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})" CHANGELOG.md
-              else
-                # Append new version (with backticks) and PR description below the anchor line
-                ANCHOR_LINE=$(awk '/All notable changes to the Zlux App Manager will be documented in this file\./ {print NR}' CHANGELOG.md)
-                sed -i "$ANCHOR_LINE a\\
-                \n## \`$VERSION\`\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
-              fi
-              git config --local user.email "action@github.com"
-              git config --local user.name "GitHub Action"
-              git add CHANGELOG.md
-              git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
-              git push
-            fi
-
-        - name: check for changes
-          id: check-change
-          run: |
-            if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
-              echo "No Changes detected, setting flag to false"
-              echo "::set-output name=change_detected::false"
+          if ! grep -Fq "$ESCAPED_CHANGELOG" CHANGELOG.md; then
+            # Check if version exists in CHANGELOG.md
+            if grep -q "^## \`$VERSION\`" CHANGELOG.md; then
+              # Append PR description to existing version
+              sed -i "/^## \`$VERSION\`/a - $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})" CHANGELOG.md
             else
-              echo "::set-output name=change_detected::true"
+              # Append new version and PR description
+              ANCHOR_LINE=$(awk '/All notable changes to the Zlux App Manager will be documented in this file\./ {print NR}' CHANGELOG.md)
+              sed -i "$ANCHOR_LINE a\\
+              \n## \`$VERSION\`\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
             fi
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add CHANGELOG.md
+            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+            git push
+          fi
+
+      - name: check for changes
+        id: check-change
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
+            echo "No Changes detected, setting flag to false"
+            echo "::set-output name=change_detected::false"
+          else
+            echo "::set-output name=change_detected::true"
+          fi
 
   check_changelog:
-      needs: update-changelog
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
+    needs: update-changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-        - name: Verify Changelog update
-          run: |
-            if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
-              echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-              exit 1
-            else
-              echo "changelog was updated successfully."
-            fi    
-
+      - name: Verify Changelog update
+        run: |
+          if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
+            echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+            exit 1
+          else
+            echo "changelog was updated successfully."
+          fi    
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -44,49 +44,95 @@ jobs:
           github-repo: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  check_changelog:
+  update-changelog:
     runs-on: ubuntu-latest
+    outputs:
+      was_updated: ${{ steps.check-change.outputs.change_detected }}
+      check_commit: ${{ steps.check-changelog.outputs.check_commit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
-            path: copy-repo
-            fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
-      - name: Get changed files
-        id: changed-files
+      - name: Check for updated CHANGELOG.md using git
+        id: check-changelog
         run: |
-            cd copy-repo
-            if ${{ github.event_name == 'pull_request' }}; then
-                echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+          if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
+            echo "CHANGELOG.md has been updated."
+            echo "::set-output name=check_commit::true"
+          else
+            echo "ERROR: CHANGELOG.md has not been updated."
+            echo "::set-output name=check_commit::false"
+          fi
+      - name: Extract changelog info
+        if: steps.check-changelog.outputs.check_commit == 'false'
+        id: extract-changelog
+        run: |
+          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+          # Check if "changelog:" exists in PR description
+          if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
+            # Extract text after "changelog:"
+            CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
+            # Extract VERSION: from PR description
+            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\Kv\d+\.\d+\.\d+')
+            echo "Extracted changelog: $CHANGELOG_TEXT"
+            echo "::set-output name=changelog::$CHANGELOG_TEXT"
+            echo "::set-output name=version::$VERSION"
+          else
+            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
+            To re-run the action, just pushed/commit the changes along with PR description, it will automatically triggered by sync."
+            exit 1
+          fi
+      - name: Check PR body against changelog
+        if: steps.check-changelog.outputs.check_commit == 'false'
+        run: |
+          if ! grep -Fq "${{ steps.extract-changelog.outputs.changelog }}" CHANGELOG.md; then
+          # Check if version exists in CHANGELOG.md
+            if grep -q "## ${{ steps.extract-changelog.outputs.version }}" CHANGELOG.md; then
+              # Append PR description to existing version
+              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} . (#${{ github.event.pull_request.number }})" CHANGELOG.md
             else
-                echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+              # Append new version and PR description
+              echo "$(awk '/All notable changes to the Zlux App Server package will be documented in this file\./ {
+                print
+                print "\n## " "${{ steps.extract-changelog.outputs.version }}"
+                print "- " "${{ steps.extract-changelog.outputs.changelog }}" " (#${{ github.event.pull_request.number }})"
+                next
+              } 1' CHANGELOG.md)" > CHANGELOG.md
+           fi
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add CHANGELOG.md
+            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+            git push
+          fi
+      - name: check for changes
+        id: check-change
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
+            echo "No Changes detected, setting flag to false"
+            echo "::set-output name=change_detected::false"
+          else
+            echo "::set-output name=change_detected::true"
+          fi
+
+  check_changelog:
+      needs: update-changelog
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+
+        - name: Verify Changelog update
+          run: |
+            if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
+              echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+              exit 1
+            else
+              echo "changelog was updated successfully."
             fi
-
-      - name: List changed files
-        id: set-flag
-        run: |
-            cd copy-repo
-            for file in ${{ steps.changed-files.outputs.changed_files }}; do
-                echo "$file was changed"
-                if [[ $file == "CHANGELOG.md" ]]
-                then
-                  echo "file-flag=true" >> $GITHUB_OUTPUT
-                  break;
-                else
-                  echo "file-flag=false" >> $GITHUB_OUTPUT
-                fi
-            done
-
-      - name: Check if CHANGELOG is Updated and Abort if not updated
-        if: steps.set-flag.outputs.file-flag != 'true'
-        run: |
-          echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-          exit 1
-
-      - name: Remove copy-repo
-        if: always()
-        run: rm -r copy-repo
         
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -81,7 +81,7 @@ jobs:
             echo "::set-output name=changelog::$CHANGELOG_TEXT"
             echo "::set-output name=version::$VERSION"
           else
-            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
+            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:X.XX.X\n CHANGELOG:This is changelog note.\n
             To re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
             exit 1
           fi

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -103,10 +103,10 @@ jobs:
               sed -i "$ANCHOR_LINE a\\
               \n## \`$VERSION\`\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
             fi
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
+            git config --global user.email "zowe-robot@users.noreply.github.com"
+            git config --global user.name "Zowe Robot"
             git add CHANGELOG.md
-            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+            git commit -s -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
             git push
           fi
 

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -76,7 +76,7 @@ jobs:
             # Extract text after "changelog:"
             CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
             # Extract VERSION: from PR description
-            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\Kv\d+\.\d+\.\d+')
+            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')
             echo "Extracted changelog: $CHANGELOG_TEXT"
             echo "::set-output name=changelog::$CHANGELOG_TEXT"
             echo "::set-output name=version::$VERSION"
@@ -92,7 +92,7 @@ jobs:
           # Check if version exists in CHANGELOG.md
             if grep -q "## ${{ steps.extract-changelog.outputs.version }}" CHANGELOG.md; then
               # Append PR description to existing version
-              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} . (#${{ github.event.pull_request.number }})" CHANGELOG.md
+              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} (#${{ github.event.pull_request.number }})" CHANGELOG.md
             else
               # Append new version and PR description
               echo "$(awk '/All notable changes to the Zlux App Server package will be documented in this file\./ {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Manager will be documented in this file.
 
 ## `2.10.0`
-- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#542)
+ 
 - Bugfix: Fixed a timing issue with the iframe-adapter for Firefox (#532)
 
 ## `2.8.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Manager will be documented in this file.
 
 ## `2.10.0`
+- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#542)
 - Bugfix: Fixed a timing issue with the iframe-adapter for Firefox (#532)
 
 ## `2.8.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to the Zlux App Manager will be documented in this file.
 
 ## `2.10.0`
-- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#542)
 - Bugfix: Fixed a timing issue with the iframe-adapter for Firefox (#532)
 
 ## `2.8.0`


### PR DESCRIPTION
VERSION: 2.10.0
CHANGELOG: This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not.