### PR TITLE
Fix not loading right desktop due to incorrect filter

### DIFF
--- a/bootstrap/src/bootstrap/bootstrap-manager.ts
+++ b/bootstrap/src/bootstrap/bootstrap-manager.ts
@@ -57,8 +57,8 @@ export class BootstrapManager {
       console.log('ZWED5008I - desktops: ', desktops);
 
       const searchParams = new URLSearchParams(window.location.search);
-      const v2Desktop = desktops.filter((desktop)=> { desktop.getIdentifier() == "org.zowe.zlux.ng2desktop" });
-      const v3Desktop = desktops.filter((desktop)=> { desktop.getIdentifier() == "org.zowe.zlux.ivydesktop" });
+      const v2Desktop = desktops.filter((desktop)=> { return desktop.getIdentifier() == "org.zowe.zlux.ng2desktop" });
+      const v3Desktop = desktops.filter((desktop)=> { return desktop.getIdentifier() == "org.zowe.zlux.ivydesktop" });
       const useV2Desktop = v2Desktop.length == 1 && searchParams.has("use-v2-desktop") && (searchParams.get("use-v2-desktop") == 'true'); 
       
       if (desktops.length == 0) {


### PR DESCRIPTION
The code to detect which desktop to use was failing because the filters were missing the return keyword causing the arrays to be empty, resulting in a defaulting to the first desktop found.