### PR TITLE
Remove uppercase visualization for Edge login input (v2)

### DIFF
--- a/virtual-desktop/src/app/authentication-manager/login/login.component.css
+++ b/virtual-desktop/src/app/authentication-manager/login/login.component.css
@@ -96,7 +96,6 @@
 
 .login-form .password {
   font-family: 'Roboto', sans-serif;
-  text-transform: uppercase;
 }
 
 .login-form label {


### PR DESCRIPTION
This PR resolves an issue for people using MS Edge.
Edge has a feature where a user can reveal the password they are typing, to confirm if it is correct.
We have a css preference set that when this happens, the text should show as uppercase.
I can only imagine this was for use with passwords, not passphrases, for familiarity.
But for passphrases this is misleading and as passphrases are the superior option, this behavior should be removed.