### PR TITLE
Fix typo in angular and react plugin factory

### DIFF
--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
@@ -81,8 +81,8 @@ export class Angular2PluginFactory extends PluginFactory {
     let pluginDefBase = pluginDefinition.getBasePlugin();
     let pluginDefAny:any = (pluginDefBase as any);
     let entryPoint = 'main.js';
-    if (pluginDefAny.getWebEntryPoint) {
-      entryPoint = pluginDefAny.getWebEntryPoint() || 'main.js';
+    if (pluginDefAny.getWebEntrypoint) {
+      entryPoint = pluginDefAny.getWebEntrypoint() || 'main.js';
     }
     return ZoweZLUX.uriBroker.pluginResourceUri(pluginDefBase, entryPoint);
   }

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/react/react-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/react/react-plugin-factory.ts
@@ -30,8 +30,8 @@ export class ReactPluginFactory extends PluginFactory {
     let pluginDefBase = pluginDefinition.getBasePlugin();
     let pluginDefAny:any = (pluginDefBase as any);
     let entryPoint = 'main.js';
-    if (pluginDefAny.getWebEntryPoint) {
-      entryPoint = pluginDefAny.getWebEntryPoint() || 'main.js';
+    if (pluginDefAny.getWebEntrypoint) {
+      entryPoint = pluginDefAny.getWebEntrypoint() || 'main.js';
     }
     return ZoweZLUX.uriBroker.pluginResourceUri(pluginDefBase, entryPoint);
   }


### PR DESCRIPTION
https://github.com/zowe/zlux-platform/blob/v3.x/staging/base/src/plugin-manager/plugin.ts#L174 defines a function called getWebEntrypoint()

It is not valid for all plugin versions, so we check for the functions existence before calling it.

However, there was a bug in which the capitalization was wrong.