### PR TITLE
Add V3 zlux-widgets back into V3 Desktop

### DIFF
--- a/virtual-desktop/package-lock.json
+++ b/virtual-desktop/package-lock.json
@@ -21,6 +21,7 @@
         "@angular/platform-browser-dynamic": "~18.0.0",
         "@angular/router": "~18.0.0",
         "@popperjs/core": "^2.11.8",
+        "@zlux/widgets": "github:wadkarsatish/zlux-widgets-angular18#widgets-Angular-Library",
         "angular-l10n": "^16.0.0",
         "bootstrap": "~5.3.2",
         "core-js": "~3.38.1",
@@ -29,7 +30,7 @@
         "ngx-file-drop": "^16.0.0",
         "ngx-i18nsupport": "~0.17.1",
         "popper.js": "~1.14.7",
-        "requirejs": "~2.3.6",
+        "requirejs": "~2.3.7",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.3",
         "typeface-roboto": "~1.1.13",
@@ -5654,6 +5655,23 @@
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
+    },
+    "node_modules/@zlux/widgets": {
+      "version": "0.0.5",
+      "resolved": "git+ssh://git@github.com/wadkarsatish/zlux-widgets-angular18.git#eeccebf9fa11d56f8b56a98f9e3ee6bc46c380f6",
+      "dependencies": {
+        "@angular/animations": "^18.0.0",
+        "@angular/common": "^18.0.0",
+        "@angular/compiler": "^18.0.0",
+        "@angular/core": "^18.0.0",
+        "@angular/forms": "^18.0.0",
+        "@angular/platform-browser": "^18.0.0",
+        "@angular/platform-browser-dynamic": "^18.0.0",
+        "@angular/router": "^18.0.0",
+        "rxjs": "~7.8.0",
+        "tslib": "^2.3.0",
+        "zone.js": "~0.14.3"
+      }
     },
     "node_modules/abbrev": {
       "version": "2.0.0",

--- a/virtual-desktop/package-lock.json
+++ b/virtual-desktop/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/platform-browser-dynamic": "~18.0.0",
         "@angular/router": "~18.0.0",
         "@popperjs/core": "^2.11.8",
-        "@zlux/widgets": "github:wadkarsatish/zlux-widgets-angular18#widgets-Angular-Library",
+        "@zlux/widgets": "github:zowe/zlux-widgets#v3.x/master",
         "angular-l10n": "^16.0.0",
         "bootstrap": "~5.3.2",
         "core-js": "~3.38.1",
@@ -5657,8 +5657,9 @@
       "dev": true
     },
     "node_modules/@zlux/widgets": {
+      "name": "zlux-widgets",
       "version": "0.0.5",
-      "resolved": "git+ssh://git@github.com/wadkarsatish/zlux-widgets-angular18.git#eeccebf9fa11d56f8b56a98f9e3ee6bc46c380f6",
+      "resolved": "git+ssh://git@github.com/zowe/zlux-widgets.git#a035805a822d40d74939829d22f616ffb225743c",
       "dependencies": {
         "@angular/animations": "^18.0.0",
         "@angular/common": "^18.0.0",

--- a/virtual-desktop/package.json
+++ b/virtual-desktop/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser-dynamic": "~18.0.0",
     "@angular/router": "~18.0.0",
     "@popperjs/core": "^2.11.8",
-    "@zlux/widgets": "github:wadkarsatish/zlux-widgets-angular18#widgets-Angular-Library",
+    "@zlux/widgets": "github:zowe/zlux-widgets#v3.x/master",
     "angular-l10n": "^16.0.0",
     "bootstrap": "~5.3.2",
     "core-js": "~3.38.1",

--- a/virtual-desktop/package.json
+++ b/virtual-desktop/package.json
@@ -27,6 +27,7 @@
     "@angular/platform-browser-dynamic": "~18.0.0",
     "@angular/router": "~18.0.0",
     "@popperjs/core": "^2.11.8",
+    "@zlux/widgets": "github:wadkarsatish/zlux-widgets-angular18#widgets-Angular-Library",
     "angular-l10n": "^16.0.0",
     "bootstrap": "~5.3.2",
     "core-js": "~3.38.1",
@@ -35,7 +36,7 @@
     "ngx-file-drop": "^16.0.0",
     "ngx-i18nsupport": "~0.17.1",
     "popper.js": "~1.14.7",
-    "requirejs": "~2.3.6",
+    "requirejs": "~2.3.7",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.3",
     "typeface-roboto": "~1.1.13",
@@ -53,5 +54,5 @@
     "tslint": "~6.1.0",
     "tslint-react": "~5.0.0",
     "typescript": "~5.4.5"
-}
+  }
 }

--- a/virtual-desktop/src/app/authentication-manager/authentication-manager.module.ts
+++ b/virtual-desktop/src/app/authentication-manager/authentication-manager.module.ts
@@ -13,7 +13,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-// import { ZluxPopupManagerModule } from '@zlux/widgets';
+import { ZluxPopupManagerModule } from '@zlux/widgets';
 import { LoginComponent } from './login/login.component';
 import { AuthenticationManager } from './authentication-manager.service';
 import { StartURLManagerModule } from '../start-url-manager';
@@ -25,7 +25,7 @@ import { provideHttpClient } from '@angular/common/http';
   imports: [
     CommonModule,
     FormsModule,
-    // ZluxPopupManagerModule,
+    ZluxPopupManagerModule,
     StartURLManagerModule,
   ],
   declarations: [

--- a/virtual-desktop/src/app/authentication-manager/idleWarn.service.ts
+++ b/virtual-desktop/src/app/authentication-manager/idleWarn.service.ts
@@ -1,9 +1,9 @@
-// import moment from 'moment';
+import moment from 'moment';
 import { Injectable } from '@angular/core';
-// import { ZluxPopupManagerService, ZluxErrorSeverity } from '@zlux/widgets';
+import { ZluxPopupManagerService, ZluxErrorSeverity } from '@zlux/widgets';
 import { L10nTranslationService } from 'angular-l10n';
 import { BaseLogger } from 'virtual-desktop-logger';
-// import { Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { StorageService } from './storage.service';
 
 @Injectable()
@@ -13,7 +13,7 @@ export class IdleWarnService {
   private readonly logger: ZLUX.ComponentLogger = BaseLogger;
   
   constructor(
-    // private popupManager: ZluxPopupManagerService,
+    private popupManager: ZluxPopupManagerService,
     public translation: L10nTranslationService,
     private storageService: StorageService  
     ) {
@@ -21,17 +21,17 @@ export class IdleWarnService {
   
   public createRetryErrorReport(renewSession: any, isIdle: any) {
     this.removeErrorReport();
-    // this.report = this.popupManager.createErrorReport(
-    //   ZluxErrorSeverity.WARNING,
-    //   this.translation.translate('Session Renewal Error'),
-    //   this.translation.translate('Session could not be renewed. Logout will occur unless renewed. Click here to retry.'), 
-    //   {
-    //     blocking: false,
-    //     buttons: [this.translation.translate('Retry'), this.translation.translate('Dismiss')]
-    //   }
-    // );
+    this.report = this.popupManager.createErrorReport(
+      ZluxErrorSeverity.WARNING,
+      this.translation.translate('Session Renewal Error'),
+      this.translation.translate('Session could not be renewed. Logout will occur unless renewed. Click here to retry.'), 
+      {
+        blocking: false,
+        buttons: [this.translation.translate('Retry'), this.translation.translate('Dismiss')]
+      }
+    );
 
-    // this.report.subscription = new Subscription();
+    this.report.subscription = new Subscription();
     this.onUserActionSubscribe(renewSession,'Retry');
     this.onActivitySubscribe(renewSession, isIdle);
   }
@@ -48,51 +48,51 @@ export class IdleWarnService {
 
   public createContinueErrorReport(renewSession: any, isIdle: any, expirationInMS: number, desktopSize: any) {
     this.removeErrorReport();
-    // let popupStyle;
+    let popupStyle;
 
-    // /* According to the size of the desktop, we move the expiration prompt to align with the app bar */
-    // switch (desktopSize) {
-    //   case 3: {
-    //     popupStyle = {
-    //       'margin-bottom': '70px',
-    //       'margin-right': '-5px'
-    //     };
-    //     break;
-    //   }
-    //   case 1: {
-    //     popupStyle = {
-    //       'margin-bottom': '15px',
-    //       'margin-right': '-10px'
-    //     };
-    //     break;
-    //   }
-    //   default: {
-    //     popupStyle = {
-    //       'margin-bottom': '35px',
-    //       'margin-right': '-5px'
-    //     };
-    //     break;
-    //   }
-    // }
+    /* According to the size of the desktop, we move the expiration prompt to align with the app bar */
+    switch (desktopSize) {
+      case 3: {
+        popupStyle = {
+          'margin-bottom': '70px',
+          'margin-right': '-5px'
+        };
+        break;
+      }
+      case 1: {
+        popupStyle = {
+          'margin-bottom': '15px',
+          'margin-right': '-10px'
+        };
+        break;
+      }
+      default: {
+        popupStyle = {
+          'margin-bottom': '35px',
+          'margin-right': '-5px'
+        };
+        break;
+      }
+    }
 
-    // this.report = this.popupManager.createErrorReport(
-    //   ZluxErrorSeverity.WARNING,
-    //   this.translation.translate('Session Expiring Soon'),
-    //   //TODO: Add translation
-    //   //this.translation.translate('You will be logged out at ', { expirationInMS: moment().add(expirationInMS/1000, 'seconds').format('LT') }),
-    //   this.translation.translate('You will be logged out at ' + moment().add(expirationInMS/1000, 'seconds').format('LT')),
-    //   {
-    //     blocking: false,
-    //     buttons: [this.translation.translate('Continue session')],
-    //     timestamp: false,
-    //     theme: "dark",
-    //     style: popupStyle,
-    //     callToAction: true
-    //   });
+    this.report = this.popupManager.createErrorReport(
+      ZluxErrorSeverity.WARNING,
+      this.translation.translate('Session Expiring Soon'),
+      //TODO: Add translation
+      //this.translation.translate('You will be logged out at ', { expirationInMS: moment().add(expirationInMS/1000, 'seconds').format('LT') }),
+      this.translation.translate('You will be logged out at ' + moment().add(expirationInMS/1000, 'seconds').format('LT')),
+      {
+        blocking: false,
+        buttons: [this.translation.translate('Continue session')],
+        timestamp: false,
+        theme: "dark",
+        style: popupStyle,
+        callToAction: true
+      });
 
-    //   this.report.subscription = new Subscription();
-    //   this.onUserActionSubscribe(renewSession, 'Continue session');
-    //   this.onActivitySubscribe(renewSession, isIdle);
+      this.report.subscription = new Subscription();
+      this.onUserActionSubscribe(renewSession, 'Continue session');
+      this.onActivitySubscribe(renewSession, isIdle);
   }
 
 
@@ -110,7 +110,7 @@ export class IdleWarnService {
 
   removeErrorReport() {
     if (this.report) {
-      // this.popupManager.removeReport(this.report.id); 
+      this.popupManager.removeReport(this.report.id); 
       this.report.subscription.unsubscribe();
       this.report = undefined;
     }

--- a/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
+++ b/virtual-desktop/src/app/plugin-manager/plugin-factory/angular2/angular2-plugin-factory.ts
@@ -144,7 +144,8 @@ export class Angular2PluginFactory extends PluginFactory {
         (plugin: MvdNativeAngularPlugin) => {
           this.translationLoaderService.getTranslationProviders(pluginDefinition.getBasePlugin()).then(providers => {
             resolve(new CompiledPlugin(plugin.pluginComponent, plugin.pluginModule, providers));
-          });
+          },
+        (failure: any) => reject(failure));
         });
     });
   }


### PR DESCRIPTION
To test,
You need to spawn a widget like the pop-up. You can spawn one quickly via:
1. use the mock server ZSS
2. go into zlux-app-manager\virtual-desktop\src\app\authentication-manager\idleWarn.service.ts

make:
removeErrorReport() {
    if (this.report) {
      // this.popupManager.removeReport(this.report.id); comment this line
      this.report.subscription.unsubscribe();
      this.report = undefined;
    }
  }
  
  zlux-app-manager\virtual-desktop\src\app\authentication-manager\login\login.component.ts
  
  make:
  renewSession(): void {
    this.spawnExpirationPrompt(50000); // add this line
    this.authenticationService.performSessionRenewal().subscribe((result: any) => {
      this.idleWarnService.removeErrorReport();
    }, (errorObservable) => {
      this.idleWarnService.createRetryErrorReport(this.renewSession, this.isIdle);
    });
  }