### PR TITLE
Add compress script to apply gzip to assets not packed by webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Manager will be documented in this file.
 
+## `3.2.0`
+
+- Enhacement: Zowe v3 Desktop assets are now compressed so that the Desktop can load faster on slow internet. (#658)
+
 ## `3.0.0`
 
 - Enhancement: Updated the Desktop Angular version from 12 to 18. This makes V2 Angular apps incompatible with V3. Iframe and React is unaffected.

--- a/virtual-desktop/gzip.mjs
+++ b/virtual-desktop/gzip.mjs
@@ -1,3 +1,13 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
@@ -5,8 +15,6 @@ import { execSync } from 'node:child_process';
 const GZIP_SIZE_MIN = 50000; //50 KB
 const GZIP_ATTEMPT_MAX = 1000000000; //1 GB. Don't try compressing large files, these likely are incompressible binary.
 const KEEP_RATIO = 0.85; // Items not compressed below this will not be kept as compressed
-
-//const COMPRESSIBLE_TYPES = ['.js', '.css', '.html', '.json', '.xml', '.xlf', 
 
 function recurse(directory) {
   const listing = fs.readdirSync(directory, {withFileTypes: true});

--- a/virtual-desktop/gzip.mjs
+++ b/virtual-desktop/gzip.mjs
@@ -1,0 +1,41 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const GZIP_SIZE_MIN = 50000; //50 KB
+const GZIP_ATTEMPT_MAX = 1000000000; //1 GB. Don't try compressing large files, these likely are incompressible binary.
+const KEEP_RATIO = 0.85; // Items not compressed below this will not be kept as compressed
+
+//const COMPRESSIBLE_TYPES = ['.js', '.css', '.html', '.json', '.xml', '.xlf', 
+
+function recurse(directory) {
+  const listing = fs.readdirSync(directory, {withFileTypes: true});
+  listing.forEach((dirent)=> {
+    let itemPath = path.join(directory, dirent.name);
+    if (dirent.isDirectory()) {
+      recurse(itemPath);
+    } else {
+      let stat = fs.statSync(itemPath);
+      if ((stat.size >= GZIP_SIZE_MIN) && (stat.size <= GZIP_ATTEMPT_MAX)) {
+        execSync('gzip -k '+dirent.name, {cwd: directory});
+        let itemPathGz = path.join(directory, dirent.name+'.gz');
+        let statGz = fs.statSync(itemPathGz);
+        //keep only one file: compressed file is kept if meaningfully smaller.
+        if ((stat.size*KEEP_RATIO) < statGz.size) {
+          fs.unlinkSync(itemPathGz);
+        } else {
+          fs.unlinkSync(itemPath);
+        }
+      }
+    }
+  });
+}
+
+try {
+  const listing = fs.readdirSync('web');  
+} catch (e) {
+  console.log('Could not read web directory, run build first.');
+  process.exit(1);
+}
+
+recurse('web');

--- a/virtual-desktop/package.json
+++ b/virtual-desktop/package.json
@@ -10,6 +10,7 @@
     "start": "ng build --watch",
     "build": "ng build && npm run copy",
     "build:externals": "exit 0",
+    "compress": "node gzip.mjs",
     "copy": "cpx node_modules/requirejs/require.js web/",
     "i18n": "ng-xi18n -p tsconfig.ngx-i18n.json --i18nFormat=xlf  --outFile=messages.xlf && xliffmerge -p xliffmerge.json",
     "lint": "tslint -c tslint.json \"src/**/*.ts\""


### PR DESCRIPTION
When v3 was made, the build script of the desktop changed from webpack to angular-cli.
As a result, our compression plugin is no longer used, and assets in the web folder do not get compressed.

Given that the command "gzip" is universally available on unix environments, I just created a node program that recursively goes through the web folder and runs "gzip" if a file is under a certain size limit and over a certain minimum size.
If the resulting gzip file isn't meaningfully smaller, it is removed. If it is small enough, the original file is removed.

The result is that this script can compress web folder contents without adding some npm library dependency.

To use this, it must be added to a build script.

Use as:

```
npm install
npm run build
npm run compress
```