### PR TITLE
config changes for zlux-editor to work

### DIFF
--- a/virtual-desktop/plugin-config/webpack5.base.js
+++ b/virtual-desktop/plugin-config/webpack5.base.js
@@ -28,11 +28,7 @@ const config = {
     }
   },
   module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        use: ['ts-loader', 'angular2-template-loader']
-      },
+    rules: [      
       {
         /* Javascript source map loader */
         enforce: 'pre',
@@ -41,17 +37,7 @@ const config = {
         exclude: [
           /\/node_modules\//
         ]
-      },
-      {
-        /* HTML URL resolution loader */
-        test: /\.html$/,
-        use: [
-          {
-            loader: 'html-loader',
-            options: { esModule: false }
-          }
-        ]
-      },
+      },      
       {
         test: /\.eot$/,
         type: 'asset/resource',

--- a/virtual-desktop/src/app/application-manager/load-failure/load-failure.component.html
+++ b/virtual-desktop/src/app/application-manager/load-failure/load-failure.component.html
@@ -16,7 +16,7 @@
 <div class="contents">
   <ul>
     <li *ngFor="let error of errors" class="error-value">
-      <span class="error-name">{{error.name}}</span>: {{error.message}}
+      <span class="error-name">{{error?.name}}</span>: {{error?.message}}
     </li>
   </ul>
 </div>

--- a/virtual-desktop/src/desktop.ts
+++ b/virtual-desktop/src/desktop.ts
@@ -105,7 +105,10 @@ script.onload = () => {
       '@angular/cdk': require('@angular/cdk'),
       'angular-l10n': require('angular-l10n'),
       'rxjs': require('rxjs'),
-      'rxjs/operators': require('rxjs/operators')
+      'rxjs/operators': require('rxjs/operators'),
+      '@angular/material/core': require('@angular/material/core'),
+      '@angular/cdk/text-field': require('@angular/cdk/text-field'),
+      '@angular/material/progress-bar': require('@angular/material/progress-bar')
     };
 
     /* Expose modules to requirejs */


### PR DESCRIPTION
This PR addresses the issues below.
1. Remove unnecessary webpack module rules. As we are using '@ngtools/webpack' to build the angular contents so no need of 'ts-loader' and 'angular2-template-loader'.
2. The same goes with a rule for loading "html" files. The compilation will be done through '@ngtools/webpack' so no need to explicitly load the html templates.
3. `desktop.ts` added few more library references which is needed for plugins(zlux-editor, file manager)