### PR TITLE
Fix app2app bug when open in new tab

### DIFF
--- a/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
+++ b/virtual-desktop/src/app/window-manager/mvd-window-manager/launchbar/shared/context-utils.ts
@@ -83,7 +83,11 @@ function openStandalone(item: LaunchbarItem): void {
       window.open(`${location.origin}${ZoweZLUX.uriBroker.pluginResourceUri(item.plugin.getBasePlugin(), pluginWebContent.startingPage)}`);
     }
   } else {
-    window.open(`${location.href}?pluginId=${item.plugin.basePlugin.getIdentifier()}&showLogin=true`);
+    if (location.href.indexOf('?') != -1) {
+      window.open(`${location.href}&pluginId=${item.plugin.basePlugin.getIdentifier()}&showLogin=true`);
+    } else {
+      window.open(`${location.href}?pluginId=${item.plugin.basePlugin.getIdentifier()}&showLogin=true`);
+    }
   }
 }
 


### PR DESCRIPTION
This is just a PR to make a test build. Do not merge yet.

A user had an issue where they couldnt use the 'open in new tab' feature of the desktop when their URL already contained some query parameters about app2app. The app2app feature was failing in that new tab.

It appears they had an invalid query parameter set where `?` was seen multiple times.
The line changed here may be the cause, I am not sure yet.
